### PR TITLE
include span in weighted elements

### DIFF
--- a/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
+++ b/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
@@ -487,7 +487,7 @@ public class ArticleTextExtractor {
         Map<Element, Object> nodes = new LinkedHashMap<Element, Object>(64);
         int score = 100;
         for (Element el : doc.select("body").select("*")) {
-            if ("p;div;td;h1;h2".contains(el.tagName())) {
+            if ("p;div;td;h1;h2;span".contains(el.tagName())) {
                 nodes.put(el, null);
                 setScore(el, score);
                 score = score / 2;


### PR DESCRIPTION
By using this I'm able to pull in articles from crazy sites such as reuters.com which span their dom to hell.

I had the same amount of breaking tests before and after that change, for the same reasons. I will deploy with this change to my staging environment but would like feedback on it from you as well.
