### PR TITLE
fix exception in keyword extraction

### DIFF
--- a/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
+++ b/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
@@ -174,7 +174,7 @@ public class ArticleTextExtractor {
 
             String[] split = content.split("\\s*,\\s*");
 
-            if (split.length > 1 || !split[0].equals(""))
+            if (split.length > 1 || (split.length > 0 && !split[0].equals("")))
                 return Arrays.asList(split);
         }
 


### PR DESCRIPTION
There is an occasional ArrayIndexOutOfBoundsException that is caused by my previous pull request. This should fix it. Typical stack below.

java.lang.ArrayIndexOutOfBoundsException: 0
        at de.jetwick.snacktory.ArticleTextExtractor.extractKeywords(ArticleTextExtractor.java:160) ~[snacktory-0.99.jar:na]
        at de.jetwick.snacktory.ArticleTextExtractor.extractContent(ArticleTextExtractor.java:131) ~[snacktory-0.99.jar:na]
        at de.jetwick.snacktory.ArticleTextExtractor.extractContent(ArticleTextExtractor.java:75) ~[snacktory-0.99.jar:na]
        at de.jetwick.snacktory.ArticleTextExtractor.extractContent(ArticleTextExtractor.java:67) ~[snacktory-0.99.jar:na]
        at de.jetwick.snacktory.ArticleTextExtractor.extractContent(ArticleTextExtractor.java:63) ~[snacktory-0.99.jar:na]
