### PR TITLE
Ensure use of slf4j over log4j in Converter class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>de.jetwick</groupId>
     <artifactId>snacktory</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Snacktory</name>

--- a/src/main/java/de/jetwick/snacktory/Converter.java
+++ b/src/main/java/de/jetwick/snacktory/Converter.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 public class Converter {
 
-    private static final Logger logger = LoggerFactory.getLogger(HtmlFetcher.class);
+    private static final Logger logger = LoggerFactory.getLogger(Converter.class);
     public final static String UTF8 = "UTF-8";
     public final static String ISO = "ISO-8859-1";
     public final static int K2 = 2048;


### PR DESCRIPTION
Basically i wanted to use snacktory in Android, but i got lots of class loading exceptions due to log4j. The main problem was the Converter class which import log4j. I fixed that problem.

12-18 23:10:01.096: WARN/dalvikvm(8715): VFY:  rejecting opcode 0x21 at 0x000a
12-18 23:10:01.096: WARN/dalvikvm(8715): VFY:  rejected Lorg/apache/log4j/config/PropertySetter;.getPropertyDescriptor (Ljava/lang/String;)Ljava/beans/PropertyDescriptor;
12-18 23:10:01.096: WARN/dalvikvm(8715): Verifier rejected class Lorg/apache/log4j/config/PropertySetter;
12-18 23:10:01.103: WARN/dalvikvm(8715): Exception Ljava/lang/VerifyError; thrown while initializing Lorg/apache/log4j/LogManager;
12-18 23:10:01.103: WARN/dalvikvm(8715): Exception Ljava/lang/ExceptionInInitializerError; thrown while initializing Lde/jetwick/snacktory/Converter;
