### PR TITLE
determineImageSource and list of images in bestMatchElement

### DIFF
--- a/src/main/java/de/jetwick/snacktory/ImageResult.java
+++ b/src/main/java/de/jetwick/snacktory/ImageResult.java
@@ -1,0 +1,34 @@
+package de.jetwick.snacktory;
+
+import org.jsoup.nodes.Element;
+
+/**
+ * Class which encapsulates the data from an image found under an element
+ * 
+ * @author Chris Alexander, chris@chris-alexander.co.uk
+ */
+public class ImageResult {    
+	public String src;
+	public Integer weight;
+	public String title;
+	public int height;
+	public int width;
+	public String alt;
+	public boolean noFollow;
+	public Element element;
+
+	public ImageResult(String src, Integer weight, String title, int height, int width, String alt, boolean noFollow) {
+		this.src = src;
+		this.weight = weight;
+		this.title = title;
+		this.height = height;
+		this.width = width;
+		this.alt = alt;
+		this.noFollow = noFollow;
+	}
+}
+    
+  
+    
+    
+

--- a/src/main/java/de/jetwick/snacktory/JResult.java
+++ b/src/main/java/de/jetwick/snacktory/JResult.java
@@ -17,6 +17,7 @@ package de.jetwick.snacktory;
 
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Parsed result from web page containing important title, text and image.
@@ -37,6 +38,7 @@ public class JResult implements Serializable {
     private String description;
     private String dateString;
     private Collection<String> keywords;
+    private List<ImageResult> images = null;
     
     public JResult() {
     }
@@ -168,6 +170,28 @@ public class JResult implements Serializable {
         return dateString;
     }
     
+    /**
+     * @return images list
+     */
+    public List<ImageResult> getImages() {
+        return images;
+    }
+
+    /**
+     * @return images count
+     */
+    public int getImagesCount() {
+    	if (images==null) return 0;
+        return images.size();
+    }
+
+    /**
+     * set images list
+     */
+    public void setImages(List<ImageResult> images) {
+        this.images = images;
+    }
+   
     @Override
     public String toString() {
         return "title:" + getTitle() + " imageUrl:" + getImageUrl() + " text:" + text;

--- a/src/test/java/de/jetwick/snacktory/ArticleTextExtractorTest.java
+++ b/src/test/java/de/jetwick/snacktory/ArticleTextExtractorTest.java
@@ -725,6 +725,22 @@ public class ArticleTextExtractorTest {
         assertTrue(article.getText(), article.getText().startsWith("Upcoming events: Forum 79 Just one week to go and everything is set for the summer Forum 2013"));
     }
 
+    @Test
+    public void testImagesList() throws Exception {
+         // http://www.reuters.com/article/2012/08/03/us-knightcapital-trading-technology-idUSBRE87203X20120803
+        JResult res = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("reuters.html")));
+        assertTrue(res.getImagesCount()==1);
+        assertEquals(res.getImages().get(0).src, "http://s1.reutersmedia.net/resources/r/?m=02&d=20120803&t=2&i=637797752&w=460&fh=&fw=&ll=&pl=&r=CBRE872074Y00");
+
+        // http://thevacationgals.com/vacation-rental-homes-are-a-family-reunion-necessity/
+        res = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("thevacationgals.html")));
+        assertTrue(res.getImagesCount()==3);
+        assertEquals(res.getImages().get(0).src, "http://thevacationgals.com/wp-content/uploads/2010/11/Gemmel-Family-Reunion-at-a-Vacation-Rental-Home1-300x225.jpg");
+        assertEquals(res.getImages().get(1).src, "../wp-content/uploads/2010/11/The-Gemmel-Family-Does-a-Gilligans-Island-Theme-Family-Reunion-Vacation-Sarah-Gemmel-300x225.jpg");
+        assertEquals(res.getImages().get(2).src, "http://www.linkwithin.com/pixel.png");
+   }
+    
+    
     /**
      * @param filePath the name of the file to open. Not sure if it can accept
      * URLs or just filenames. Path handling could be better, and buffer sizes


### PR DESCRIPTION
determineImageSource builds a list of ImageResult items. JResult class provides two methods in order to get this list :
    public List<ImageResult> getImages()
    public int getImagesCount() 

the API is not broken
the unit tests succeed
a unit test was created for this feature

The code is partially based on "Multi image" pull request by chrisalexander 
