### PR TITLE
Fix issue #10 allow users to set a proxy

### DIFF
--- a/src/main/java/de/jetwick/snacktory/HtmlFetcher.java
+++ b/src/main/java/de/jetwick/snacktory/HtmlFetcher.java
@@ -22,8 +22,11 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.Proxy;
+import java.net.Proxy.Type;
+import java.net.SocketAddress;
 import java.net.URL;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -31,6 +34,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,6 +83,9 @@ public class HtmlFetcher {
     private String accept = "application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5";
     private String charset = "UTF-8";
     private SCache cache;
+    private String proxyServer = null;
+    private int proxyPort = 0;
+    private Type proxyType = null;
     private AtomicInteger cacheCounter = new AtomicInteger(0);
     private int maxTextLength = -1;
     private ArticleTextExtractor extractor = new ArticleTextExtractor();
@@ -198,6 +205,35 @@ public class HtmlFetcher {
 
     public String getCharset() {
         return charset;
+    }
+
+    public void setProxyServer(String proxyServer) {
+        this.proxyServer = proxyServer;
+    }
+
+    public String getProxyServer() {
+        return proxyServer;
+    }
+
+    public void setProxyPort(int proxyPort) {
+        this.proxyPort = proxyPort;
+    }
+
+    public int getProxyPort() {
+        return proxyPort;
+    }
+
+    public boolean isProxySet() {
+        return (this.proxyServer != null && !this.proxyServer.trim().equals(""))
+                && this.proxyPort > 0;
+    }
+
+    public void setProxyType(String proxyType) {
+        this.proxyType = Type.valueOf(proxyType);
+    }
+
+    public String getProxyType() {
+        return (this.proxyType != null) ? this.proxyType.name() : null;
     }
 
     public JResult fetchAndExtract(String url, int timeout, boolean resolve) throws Exception {
@@ -363,7 +399,7 @@ public class HtmlFetcher {
                 return urlAsString;
 
         } catch (Exception ex) {
-            logger.warn("getResolvedUrl:" + urlAsString + " Error:" + ex.getMessage());
+            logger.warn("getResolvedUrl:" + urlAsString + " Error:" + ex.getMessage(), ex);
             return "";
         } finally {
             if (logger.isDebugEnabled())
@@ -395,7 +431,13 @@ public class HtmlFetcher {
             boolean includeSomeGooseOptions) throws MalformedURLException, IOException {
         URL url = new URL(urlAsStr);
         //using proxy may increase latency
-        HttpURLConnection hConn = (HttpURLConnection) url.openConnection(Proxy.NO_PROXY);
+        Proxy proxy = Proxy.NO_PROXY;
+        if (isProxySet()) {
+            SocketAddress socketAddress = new InetSocketAddress(getProxyServer(), getProxyPort());
+            Type proxyType = Type.valueOf(getProxyType());
+            proxy = new Proxy(proxyType, socketAddress);
+        }
+        HttpURLConnection hConn = (HttpURLConnection) url.openConnection(proxy);
         hConn.setRequestProperty("User-Agent", userAgent);
         hConn.setRequestProperty("Accept", accept);
 

--- a/src/main/java/de/jetwick/snacktory/HtmlFetcher.java
+++ b/src/main/java/de/jetwick/snacktory/HtmlFetcher.java
@@ -22,11 +22,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
-import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.Proxy;
-import java.net.Proxy.Type;
-import java.net.SocketAddress;
 import java.net.URL;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -83,9 +80,7 @@ public class HtmlFetcher {
     private String accept = "application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5";
     private String charset = "UTF-8";
     private SCache cache;
-    private String proxyServer = null;
-    private int proxyPort = 0;
-    private Type proxyType = null;
+    private Proxy proxy = null;
     private AtomicInteger cacheCounter = new AtomicInteger(0);
     private int maxTextLength = -1;
     private ArticleTextExtractor extractor = new ArticleTextExtractor();
@@ -207,33 +202,16 @@ public class HtmlFetcher {
         return charset;
     }
 
-    public void setProxyServer(String proxyServer) {
-        this.proxyServer = proxyServer;
+    public void setProxy(Proxy proxy) {
+        this.proxy = proxy;
     }
 
-    public String getProxyServer() {
-        return proxyServer;
-    }
-
-    public void setProxyPort(int proxyPort) {
-        this.proxyPort = proxyPort;
-    }
-
-    public int getProxyPort() {
-        return proxyPort;
+    public Proxy getProxy() {
+        return (proxy != null ? proxy : Proxy.NO_PROXY);
     }
 
     public boolean isProxySet() {
-        return (this.proxyServer != null && !this.proxyServer.trim().equals(""))
-                && this.proxyPort > 0;
-    }
-
-    public void setProxyType(String proxyType) {
-        this.proxyType = Type.valueOf(proxyType);
-    }
-
-    public String getProxyType() {
-        return (this.proxyType != null) ? this.proxyType.name() : null;
+        return getProxy() != null;
     }
 
     public JResult fetchAndExtract(String url, int timeout, boolean resolve) throws Exception {
@@ -431,12 +409,7 @@ public class HtmlFetcher {
             boolean includeSomeGooseOptions) throws MalformedURLException, IOException {
         URL url = new URL(urlAsStr);
         //using proxy may increase latency
-        Proxy proxy = Proxy.NO_PROXY;
-        if (isProxySet()) {
-            SocketAddress socketAddress = new InetSocketAddress(getProxyServer(), getProxyPort());
-            Type proxyType = Type.valueOf(getProxyType());
-            proxy = new Proxy(proxyType, socketAddress);
-        }
+        Proxy proxy = getProxy();
         HttpURLConnection hConn = (HttpURLConnection) url.openConnection(proxy);
         hConn.setRequestProperty("User-Agent", userAgent);
         hConn.setRequestProperty("Accept", accept);

--- a/src/test/java/de/jetwick/snacktory/HtmlFetcherProxyTest.java
+++ b/src/test/java/de/jetwick/snacktory/HtmlFetcherProxyTest.java
@@ -1,0 +1,49 @@
+package de.jetwick.snacktory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
+
+/**
+ * Tests for HtmlFetcher proxy feature.
+ */
+public class HtmlFetcherProxyTest {
+
+    public HtmlFetcherProxyTest() {
+    }
+
+    @Test
+    public void testNoProxy() {
+        HtmlFetcher fetcher = new HtmlFetcher();
+        assertFalse("HtmlFetcher proxy was already set", fetcher.isProxySet());
+    }
+
+    @Test
+    public void testSocksProxy() {
+        HtmlFetcher fetcher = new HtmlFetcher();
+        fetcher.setProxyPort(3128);
+        fetcher.setProxyServer("127.0.0.1");
+        fetcher.setProxyType("SOCKS");
+
+        assertEquals("Invalid SOCKS proxy type name", "SOCKS", fetcher.getProxyType());
+    }
+
+    @Test
+    public void testProxyPort() {
+        HtmlFetcher fetcher = new HtmlFetcher();
+        assertEquals("HtmlFetcher proxy port was not zero", Integer.valueOf(0), Integer.valueOf(fetcher.getProxyPort()));
+    }
+
+    @Test
+    public void testProxyServer() {
+        HtmlFetcher fetcher = new HtmlFetcher();
+        assertEquals("HtmlFetch proxy server was not empty", null, fetcher.getProxyServer());
+    }
+
+    public void testProxyType() {
+        HtmlFetcher fetcher = new HtmlFetcher();
+        assertEquals("HtmlFetch proxy type was not null", null, fetcher.getProxyType());
+    }
+
+}

--- a/src/test/java/de/jetwick/snacktory/HtmlFetcherProxyTest.java
+++ b/src/test/java/de/jetwick/snacktory/HtmlFetcherProxyTest.java
@@ -1,7 +1,25 @@
+/*
+ *  Copyright 2015 Peter Karich 
+ * 
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package de.jetwick.snacktory;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.Proxy.Type;
 
 import org.junit.Test;
 
@@ -14,36 +32,18 @@ public class HtmlFetcherProxyTest {
     }
 
     @Test
-    public void testNoProxy() {
-        HtmlFetcher fetcher = new HtmlFetcher();
-        assertFalse("HtmlFetcher proxy was already set", fetcher.isProxySet());
-    }
-
-    @Test
     public void testSocksProxy() {
         HtmlFetcher fetcher = new HtmlFetcher();
-        fetcher.setProxyPort(3128);
-        fetcher.setProxyServer("127.0.0.1");
-        fetcher.setProxyType("SOCKS");
+        Proxy proxy = new Proxy(Type.valueOf("SOCKS"), new InetSocketAddress("127.0.0.1", 3128));
+        fetcher.setProxy(proxy);
 
-        assertEquals("Invalid SOCKS proxy type name", "SOCKS", fetcher.getProxyType());
+        assertEquals("Invalid SOCKS proxy type name", "SOCKS", fetcher.getProxy().type().name());
     }
 
     @Test
-    public void testProxyPort() {
+    public void testNoProxy() {
         HtmlFetcher fetcher = new HtmlFetcher();
-        assertEquals("HtmlFetcher proxy port was not zero", Integer.valueOf(0), Integer.valueOf(fetcher.getProxyPort()));
-    }
-
-    @Test
-    public void testProxyServer() {
-        HtmlFetcher fetcher = new HtmlFetcher();
-        assertEquals("HtmlFetch proxy server was not empty", null, fetcher.getProxyServer());
-    }
-
-    public void testProxyType() {
-        HtmlFetcher fetcher = new HtmlFetcher();
-        assertEquals("HtmlFetch proxy type was not null", null, fetcher.getProxyType());
+        assertEquals("HtmlFetch proxy server was not a NO_PROXY proxy", Proxy.NO_PROXY, fetcher.getProxy());
     }
 
 }


### PR DESCRIPTION
Hi @karussell, 

Here's a first tentative to add proxies to Snacktory (thanks for writing it by the way). I didn't want to expose the Type object in Snacktory API, so users have to provide the proxy type as text (they can use the Type enum to get the type name). 

Some simple JUNit tests attached. Tried to keep the code style (no tabs), but feel free to further massage the code if needed, as I didn't spend much time looking at the rest of the code to standardize the code.

Successfully tested with Snacktory against a CNTLM HTTP proxy and a SSH SOCKS proxy. Both seemed to work, but as your comment in the code suggested, quite slow.

Hope that helps,
Bruno