### PR TITLE
Fix Issue #42 to improve content identification

### DIFF
--- a/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
+++ b/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
@@ -307,6 +307,10 @@ public class ArticleTextExtractor {
         List<Element> pEls = new ArrayList<Element>(5);
         for (Element child : rootEl.children()) {
             String ownText = child.ownText();
+
+            // if you are on a paragraph, grab all the text including that surrounded by additional formatting.
+            if (child.tagName().equals("p")) ownText = child.text();
+
             int ownTextLength = ownText.length();
             if (ownTextLength < 20)
                 continue;

--- a/src/test/java/de/jetwick/snacktory/ArticleTextExtractorTest.java
+++ b/src/test/java/de/jetwick/snacktory/ArticleTextExtractorTest.java
@@ -61,6 +61,12 @@ public class ArticleTextExtractorTest {
     }
 
     @Test
+    public void testData6() throws Exception {
+        JResult res = extractor.extractContent(readFileAsString("test_data/6.html"));
+        assertEquals(res.getText(), "Acting Governor of Balkh province, Atta Mohammad Noor, said that differences between leaders of the National Unity Government (NUG) – namely President Ashraf Ghani and CEO Abdullah Abdullah— have paved the ground for mounting insecurity. Hundreds of worried relatives gathered outside Kabul hospitals on Tuesday desperate for news of loved ones following the deadly suicide bombing earlier in the day.");
+    }
+
+    @Test
     public void testCNN() throws Exception {
         // http://edition.cnn.com/2011/WORLD/africa/04/06/libya.war/index.html?on.cnn=1
         JResult res = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("cnn.html")));

--- a/test_data/6.html
+++ b/test_data/6.html
@@ -1,0 +1,1132 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-gb" lang="en-gb">
+<head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
+ 
+<script type="text/javascript">
+_atrk_opts = { atrk_acct:"XaDBj1aEsk00W1", domain:"tolonews.com",dynamic: true};
+(function() { var as = document.createElement('script'); as.type = 'text/javascript'; as.async = true; as.src = "https://d31qbv1cthcecs.cloudfront.net/atrk.js"; var s = document.getElementsByTagName('script')[0];s.parentNode.insertBefore(as, s); })();
+</script>
+<noscript><img src="https://d5nxst8fruw4z.cloudfront.net/atrk.gif?account=XaDBj1aEsk00W1" style="display:none" height="1" width="1" alt=""/></noscript>
+ 
+<meta name="robots" content="NOARCHIVE">
+<link rel="stylesheet" type="text/css" href="http://www.tolonews.com/templates/rt_quantive_j15_new/css/sharebar_wrapper.css">
+<link rel="stylesheet" type="text/css" href="http://www.tolonews.com/templates/rt_quantive_j15_new/css/sharebar_story.css?r=2012040501">
+<script type="text/javascript" src="http://www.tolonews.com/templates/rt_quantive_j15_new/js/sharebar-pack.js"></script>
+<script type="text/javascript" src="http://cdn.gigya.com/js/socialize.js?apiKey=3_63i_rghXOOveF2LEuQi5_vPMSdNUnQMS7-Nn80qSaDzTXyxSjh67KJIjzKhiQWuK"></script>
+<link rel="canonical" href="http://www.tolonews.com/en/video/24865-tolonews-6pm-news-19-april-2016">
+<script type="text/javascript" src="http://e.yieldmanager.net/script.js"></script>
+<base href="http://www.tolonews.com/video/24865-tolonews-6pm-news-19-april-2016"/>
+<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+<meta name="robots" content="index, follow"/>
+<meta name="keywords" content="6pm News, bulletin, TOLOtv, TOLOnews, Kabul, Afghanistan"/>
+<meta name="title" content="TOLOnews 6pm News 19 April 2016"/>
+<meta name="author" content="Faridullah.Sahil"/>
+<meta name="description" content="Acting Governor of Balkh province, Atta Mohammad Noor, said that differences between leaders of the National Unity Government (NUG) – namely President Ashraf Ghani and CEO Abdullah Abdullah— have paved the ground for mounting insecurity."/>
+<meta name="generator" content="Joomla! 1.5 - Open Source Content Management"/>
+<title>TOLOnews 6pm News 19 April 2016</title>
+<link href="/templates/rt_quantive_j15_new/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+<link href="http://tolonews.com/index.php?option=com_ninjarsssyndicator&amp;feed_id=1&amp;format=raw" rel="alternate" type="application/rss+xml" title="TOLOnews.com RSS Feed"/>
+<link rel="stylesheet" href="/components/com_gantry/css/gantry.css" type="text/css"/>
+<link rel="stylesheet" href="/components/com_gantry/css/grid-12.css" type="text/css"/>
+<link rel="stylesheet" href="/components/com_gantry/css/joomla.css" type="text/css"/>
+<link rel="stylesheet" href="/templates/rt_quantive_j15_new/css/joomla.css" type="text/css"/>
+<link rel="stylesheet" href="/templates/rt_quantive_j15_new/css/style4.css" type="text/css"/>
+<link rel="stylesheet" href="/templates/rt_quantive_j15_new/css/light-body.css" type="text/css"/>
+<link rel="stylesheet" href="/templates/rt_quantive_j15_new/css/demo-styles.css" type="text/css"/>
+<link rel="stylesheet" href="/templates/rt_quantive_j15_new/css/splitmenu.css" type="text/css"/>
+<link rel="stylesheet" href="/templates/rt_quantive_j15_new/css/template.css" type="text/css"/>
+<link rel="stylesheet" href="/templates/rt_quantive_j15_new/css/template-firefox.css" type="text/css"/>
+<link rel="stylesheet" href="/templates/rt_quantive_j15_new/css/typography.css" type="text/css"/>
+<link rel="stylesheet" href="/modules/mod_jflanguageselection/tmpl/mod_jflanguageselection.css" type="text/css"/>
+<link rel="stylesheet" href="http://tolonews.com/modules/mod_gk_news_highlighter/style/style.php?suffix=news-highlight-1&amp;moduleHeight=24&amp;moduleWidth=300&amp;interfaceWidth=0&amp;extra_divs=0&amp;bgcolor=ransparent&amp;bordercolor=ransparent&amp;set=0&amp;linkcolor=666666&amp;hlinkcolor=666666&amp;textleft_color=666666&amp;textleft_style=bold" type="text/css"/>
+<style type="text/css"><!--
+#rt-main-surround ul.menu li.active > a, #rt-main-surround ul.menu li.active > .separator, #rt-main-surround ul.menu li.active > .item, #rt-main-surround .square4 ul.menu li:hover > a, #rt-main-surround .square4 ul.menu li:hover > .item, #rt-main-surround .square4 ul.menu li:hover > .separator, .roktabs-links ul li.active span {color:#004276;}
+a, #rt-main-surround ul.menu a:hover, #rt-main-surround ul.menu .separator:hover, #rt-main-surround ul.menu .item:hover {color:#004276;}
+body #rt-logo {width:150px;height:92px;}
+#dm_tabs_1 ul.dm_menu_1 { width:auto; margin:0; padding:0; list-style:none; }
+#dm_tabs_1 ul.dm_menu_1 li.dm_menu_item_1 { display: inline; margin:0 0 0 0; padding:0; float:left; border:1px solid #CCCCCC; border-bottom:none; background-color:#F6F6F6; background-image:none; }
+#dm_tabs_1 ul.dm_menu_1 li.dm_menu_item_1 a { font:bold 13px Arial; float:left; border:none; color:#000000; padding:5px 11px 5px 11px; text-decoration:none; }
+#dm_tabs_1 ul.dm_menu_1 li.dm_menu_item_1 a.dm_selected { position:relative;top:1px;background-color:#FFFFFF;color:#135CAE; }
+#dm_tabs_1 ul.dm_menu_1 li.dm_menu_item_1 a:hover {background-color:#FFFFFF;color:#135CAE; }
+#dm_container_1 {border:1px solid #CCCCCC;width:auto;height:auto;background-color:#FFFFFF;padding:5px;overflow:hidden; }
+#dm_container_1 .dm_tabcontent {display:none; }
+@media print { #dm_container_1 .dm_tabcontent {display:block !important; } }
+    --></style>
+<script type="text/javascript" src="/media/system/js/mootools.js"></script>
+<script type="text/javascript" src="/media/system/js/caption.js"></script>
+<script type="text/javascript" src="/components/com_gantry/js/gantry-buildspans.js"></script>
+<script type="text/javascript" src="/components/com_gantry/js/gantry-inputs.js"></script>
+<script type="text/javascript" src="/modules/mod_dinamods/js/dinamods.js"></script>
+<script type="text/javascript" src="http://tolonews.com/modules/mod_gk_news_highlighter/scripts/engine_compress.js"></script>
+<script type="text/javascript" src="http://tolonews.com/modules/mod_gk_news_highlighter/scripts/importer.php?module_id=news-highlight-1&amp;animation_type=6&amp;animation_speed=250&amp;animation_interval=5000&amp;animation_fun=Fx.Transitions.linear&amp;mouseover=1"></script>
+<script type="text/javascript">
+
+			window.addEvent('domready', function() {
+				var modules = ['rt-block'];
+				var header = ['h3','h2','h1'];
+				GantryBuildSpans(modules, header);
+			});
+		
+InputsExclusion.push('.content_vote','#rt-popup')
+function addLoadEvent(func) { if (typeof window.onload != 'function') { window.onload = func; } else { var oldonload = window.onload; window.onload = function() { if (oldonload) { oldonload(); } func(); } } }
+addLoadEvent(function(){
+var Dinamods=new dinamods('dm_tabs_1');
+Dinamods.setpersist(true);
+Dinamods.setselectedClassTarget('link');
+Dinamods.init(0,0);});
+  </script>
+<script type='text/javascript'>
+/*<![CDATA[*/
+	var jax_live_site = 'http://www.tolonews.com/index.php';
+	var jax_site_type = '1.5';
+/*]]>*/
+</script><script type="text/javascript" src="http://www.tolonews.com/plugins/system/pc_includes/ajax_1.2.js"></script>
+<link rel="stylesheet" type="text/css" href="http://www.tolonews.com/components/com_jomcomment/style.css"/>
+<link rel="stylesheet" type="text/css" href="http://www.tolonews.com/components/com_jomcomment/templates/default/comment_style.css"/>
+<script type='text/javascript'>
+/*<![CDATA[*/
+var jc_option           = "";
+var jc_autoUpdate       = "0";
+var jc_update_period    = 0*1000;
+var jc_orderBy          = "0";
+var jc_livesite_busyImg = "http://www.tolonews.com/components/com_jomcomment/busy.gif";
+var jc_username         = "";
+var jc_email            = "";
+var jc_commentForm;
+/*]]>*/
+</script>
+ 
+<style type="text/css" media="all">@import "http://tolonews.com/plugins/content/jw_allvideos/tmpl/css/template.css";</style>
+<script type="text/javascript" src="http://tolonews.com/plugins/content/jw_allvideos/includes/players/wmvplayer/silverlight.js"></script>
+<script type="text/javascript" src="http://tolonews.com/plugins/content/jw_allvideos/includes/players/wmvplayer/wmvplayer.js"></script>
+<script type="text/javascript" src="http://tolonews.com/plugins/content/jw_allvideos/includes/players/quicktimeplayer/AC_QuickTime.js"></script>
+<script type="text/javascript" src="http://tolonews.com/plugins/content/jw_allvideos/includes/jw_allvideos.js"></script>
+ 
+<meta property="fb:app_id" content="124533801006682"/>
+<script type="text/javascript">
+
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-2894162-14', 'auto');
+  ga('send', 'pageview');
+
+</script>
+</head>
+<body class="backgroundlevel-med backgroundstyle-style4 bodylevel-med bodystyle-light cssstyle-style4 logostyle-light font-family-helvetica font-size-is-default menu-type-splitmenu col12 ">
+ 
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-MX3L4T" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MX3L4T');</script>
+ 
+<div id="rt-main-background" style="overflow:hidden;">
+<div class="rt-container">
+<div id="rt-drawer">
+<div class="rt-grid-12 rt-alpha rt-omega">
+<div class="clear"></div>
+</div>
+<div class="clear"></div>
+</div>
+<div id="rt-header">
+<font color="#FFFFFF" style="font-size:12px;">
+<div class="rt-grid-3 rt-alpha">
+<div class="rt-block">
+<a href="/" id="rt-logo"></a>
+</div>
+</div>
+<div class="rt-grid-5">
+<div class="slide">
+<div class="rt-block">
+<div class="rt-module-surround">
+<div class="rt-module-top11 ">
+<div class="rt-module-top21 ">
+<div class="rt-module-top31 ">
+</div></div></div>
+<div class="rt-module-inner1 ">
+<div class="module-content">
+<div class="gk_news_highlighter" id="news-highlight-1">
+<div class="gk_news_highlighter_wrapper">
+<div class="gk_news_highlighter_item"><a href="/en/afghanistan/25206-ghani-leaves-kabul-for-two-day-visit-to-tajikistan"><span class="gk_news_highlighter_title">Ghani Leaves Kabul for Two Day Visit to Tajikistan</span></a></div>
+<div class="gk_news_highlighter_item"><a href="/en/afghanistan/25203-noor-criticizes-govt-for-not-consulting-on-executions"><span class="gk_news_highlighter_title">Noor Criticizes Govt For Not Consulting On Executi...</span></a></div>
+<div class="gk_news_highlighter_item"><a href="/en/afghanistan/25202-tutap-protestors-set-deadline-as-ghani-pledges-review"><span class="gk_news_highlighter_title">TUTAP Protestors Set Deadline As Ghani Pledges Rev...</span></a></div>
+<div class="gk_news_highlighter_item"><a href="/en/afghanistan/25201-report-speaks-of-confusion-among-us-soldiers-afghan-mission"><span class="gk_news_highlighter_title">Report Speaks Of Confusion Among U.S Soldiers' Afg...</span></a></div>
+<div class="gk_news_highlighter_item"><a href="/en/afghanistan/25200-calls-mount-for-more-executions"><span class="gk_news_highlighter_title">Calls Mount For More Executions</span></a></div>
+<div class="gk_news_highlighter_item"><a href="/en/afghanistan/25199-through-the-window-of-a-kabul-widows-mud-house"><span class="gk_news_highlighter_title">Through The Window Of A Kabul Widow's Mud House</span></a></div>
+<div class="gk_news_highlighter_item"><a href="/en/afghanistan/25198-senior-officials-accused-of-activities-outside-of-their-authority"><span class="gk_news_highlighter_title">Senior Officials Accused Of Activities Outside Of ...</span></a></div>
+<div class="gk_news_highlighter_item"><a href="/en/afghanistan/25197-masoud-urges-strong-democracy-cautions-centralized-system"><span class="gk_news_highlighter_title">Masoud Urges Strong Democracy, Cautions Centralize...</span></a></div>
+<div class="gk_news_highlighter_item"><a href="/en/afghanistan/25196-19-military-operations-underway-in-15-provinces-mod"><span class="gk_news_highlighter_title">19 Military Operations Underway In 15 Provinces: M...</span></a></div>
+<div class="gk_news_highlighter_item"><a href="/en/afghanistan/25188-six-killed-in-shootout-on-truck-smuggling-afghans-into-iran"><span class="gk_news_highlighter_title">Six Killed In Shootout On Truck Smuggling Afghans ...</span></a></div>
+</div>
+</div>
+</div>
+</div>
+<div class="rt-module-bottom1 ">
+<div class="rt-module-bottom21 ">
+<div class="rrt-module-bottom31 ">
+</div></div></div>
+</div>
+</div>
+</div>
+<div class="slide">
+<div class="rt-block">
+<div class="rt-module-surround">
+<div class="rt-module-top11 ">
+<div class="rt-module-top21 ">
+<div class="rt-module-top31 ">
+</div></div></div>
+<div class="rt-module-inner1 ">
+<div class="module-content">
+ 
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<script src="http://www.tolonews.com/elections2014/misc/jquery.js?v=1.4.4"></script>
+<script>
+//$('.fadein img:gt(0)').hide();
+
+setInterval(function () {
+    $('.fadein :first-child').next('img')
+                             .fadeIn()
+                             .end()
+                             .appendTo('.fadein');
+}, 5000); // 4 seconds
+
+/*setInterval(function () {
+    $('.fadein :first-child').fadeOut()
+                             .next('img')
+                             .fadeIn()
+                             .end()
+                             .appendTo('.fadein');
+}, 4000); // 4 seconds*/
+</script>
+<style type="text/css">.fadein{position:relative;}.fadein img{position:absolute;left:0;top:0;}</style>
+</head>
+<body>
+<div class="fadein">
+<img onclick="window.open('http://www.tolonews.com/en/watch-tolonews/17115-watch-tolonews');_gaq.push(['_trackEvent','TOLOnews_newfrequency_15_01_2014_english','TOLOnews_newfrequency_15_01_2014_english','TOLOnews_newfrequency_15_01_2014_english',,false]);
+        " style="display: block; margin-left: auto; margin-right: auto; padding-top: 15px; padding-left: 22px;" src="/images/social/TOLOnews_Frequency_banner_new_v1.png"/>
+</div>
+</body>
+</html>
+ 
+</div>
+</div>
+<div class="rt-module-bottom1 ">
+<div class="rt-module-bottom21 ">
+<div class="rrt-module-bottom31 ">
+</div></div></div>
+</div>
+</div>
+</div>
+</div>
+<div class="rt-grid-2">
+<div class="language">
+<div class="rt-block">
+<div class="rt-module-surround">
+<div class="rt-module-top11 ">
+<div class="rt-module-top21 ">
+<div class="rt-module-top31 ">
+</div></div></div>
+<div class="rt-module-inner1 ">
+<div class="module-content">
+<div id="social-icon"><a href="https://plus.google.com/+TOLOnews" target="_blank" rel="publisher"><img style="margin-right: 3px; margin-left: 5px;" src="/images/social/gp-new2.png" alt=""/></a><a href="http://www.youtube.com/user/TOLOnewsLive" target="_blank"><img src="/images/social/yt-new2.png" alt=""/></a> <a href="https://www.facebook.com/TOLOnews" target="_blank"><img src="/images/social/fb-new2.png" alt=""/></a> <a href="http://www.twitter.com/TOLOnews" target="_blank"><img src="/images/social/tw-new2.png" alt=""/></a> <a href="/en/component/ninjarsssyndicator/?feed_id=1&amp;format=raw" target="_blank"><img src="/images/social/rss-new2.png" alt=""/></a> <a href="http://instagram.com/tolonewsOfficial" target="_blank"><img style="margin-right: 0px; margin-left: 0px;" src="/images/social/instagram.png" alt="Instagram"/></a></div> </div>
+</div>
+<div class="rt-module-bottom1 ">
+<div class="rt-module-bottom21 ">
+<div class="rrt-module-bottom31 ">
+</div></div></div>
+</div>
+</div>
+</div>
+</div>
+<div class="rt-grid-2 rt-omega">
+<div class="date-block">
+<span class="date">Tuesday 10 May 2016</span>
+</div>
+<div class="search">
+<div class="rt-block">
+<div class="rt-module-surround">
+<div class="rt-module-top11 ">
+<div class="rt-module-top21 ">
+<div class="rt-module-top31 ">
+</div></div></div>
+<div class="rt-module-inner1 ">
+<div class="module-content">
+<form action="index.php" method="post">
+<div class="searchsearch">
+<input name="searchword" id="mod_search_searchword" maxlength="20" alt="Search" class="inputboxsearch" type="text" size="20" value="search..." onblur="if(this.value=='') this.value='search...';" onfocus="if(this.value=='search...') this.value='';"/> </div>
+<input type="hidden" name="task" value="search"/>
+<input type="hidden" name="option" value="com_search"/>
+<input type="hidden" name="Itemid" value="339"/>
+</form> </div>
+</div>
+<div class="rt-module-bottom1 ">
+<div class="rt-module-bottom21 ">
+<div class="rrt-module-bottom31 ">
+</div></div></div>
+</div>
+</div>
+</div>
+<div class="language">
+<div class="rt-block">
+<div class="rt-module-surround">
+<div class="rt-module-top11 ">
+<div class="rt-module-top21 ">
+<div class="rt-module-top31 ">
+</div></div></div>
+<div class="rt-module-inner1 ">
+<div class="module-content">
+<div id="jflanguageselection"><ul class="jflanguageselection"><li id="active_language"><a href="http://www.tolonews.com/en/video/24865-tolonews-6pm-news-19-april-2016"><span lang="en" xml:lang="en">English</span></a></li><li><a href="http://www.tolonews.com/pa/video/24865-tolonews-6pm-news-19-april-2016"><span lang="pa" xml:lang="pa">  پشتو  </span></a></li><li><a href="http://www.tolonews.com/fa/video/24865-tolonews-6pm-news-19-april-2016"><span lang="fa" xml:lang="fa">فارسی</span></a></li></ul></div> 
+ 
+ 
+</div>
+</div>
+<div class="rt-module-bottom1 ">
+<div class="rt-module-bottom21 ">
+<div class="rrt-module-bottom31 ">
+</div></div></div>
+</div>
+</div>
+</div>
+</div>
+</font>
+<div class="clear"></div>
+</div>
+<div id="rt-navigation"><div id="rt-navigation2"><div id="rt-navigation3">
+<div class='nopill'><ul class="menutop level1">
+<li class="item1 parent">
+<a class="orphan item" href="http://tolonews.com/">
+<span>
+News
+</span>
+</a>
+</li>
+<li class="item61">
+<a class="orphan item" href="/en/photos">
+<span>
+Photos
+</span>
+</a>
+</li>
+<li class="item4 parent active">
+<a class="orphan item" href="/en/video">
+<span>
+Video
+</span>
+</a>
+</li>
+<li class="item35 parent">
+<a class="orphan item" href="/en/blogs-a-opinion">
+<span>
+Blogs &amp; Opinion
+</span>
+</a>
+</li>
+<li class="item331">
+<a class="orphan item" href="/en/arts-and-cultures">
+<span>
+Arts &amp; Culture
+</span>
+</a>
+</li>
+<li class="item37 parent">
+<a class="orphan item" href="/en/programmes">
+<span>
+Programmes
+</span>
+</a>
+</li>
+<li class="item347">
+<a class="orphan item" href="http://govmeter.tolonews.com/" target="_blank">
+<span>
+Govmeter
+</span>
+</a>
+</li>
+<li class="item291">
+<a class="orphan item" href="/en/watch-tolonews">
+<span>
+Watch TOLOnews
+</span>
+</a>
+</li>
+</ul>
+</div>
+<div class="clear"></div>
+</div></div></div>
+<div class="rt-submenu-surround"><div class="rt-submenu-surround2">
+<div id="rt-submenu">
+<div class='nopill'><ul class="menu level1">
+<li class="item5">
+<a class="orphan item" href="/en/video/nightly-news">
+<span>
+Nightly News
+</span>
+</a>
+</li>
+<li class="item8">
+<a class="orphan item" href="/en/video/newshour">
+<span>
+Newshour
+</span>
+</a>
+</li>
+<li class="item167">
+<a class="orphan item" href="/en/video/black-a-white">
+<span>
+Black &amp; White
+</span>
+</a>
+</li>
+<li class="item175">
+<a class="orphan item" href="/en/video/kankash">
+<span>
+Kankash
+</span>
+</a>
+</li>
+</ul>
+</div>
+<div class="clear"></div>
+</div>
+</div></div>
+<script>
+clsHash = {'id6':'item2','id2':'item3','id3':'item6','id4':'item7'}
+urlHash = window.location.href.slice(window.location.href.indexOf('?')+1).split('&')
+var id = null
+for (key in urlHash) {
+	k = urlHash[key].toString().split('=');
+	if (k[0] == 'id') {
+		id = k[1];
+		break;
+	}
+}
+menu = document.getElementsByClassName('menu level1').length ? document.getElementsByClassName('menu level1')[0] : null;
+currActive = menu && menu.getElementsByClassName('active').length ? menu.getElementsByClassName('active')[0] : null;
+if (currActive) currActive.className = currActive.className.replace('active','');
+if (menu && id && menu.getElementsByClassName(eval('clsHash.id'+id)))
+	menu.getElementsByClassName(eval('clsHash.id'+id))[0].className += ' active';
+
+
+</script>
+ 
+<div id="rt-submenu" style="z-index:20000;height:70px;background-image:url(http://tolonews.com/templates/rt_quantive_j15_new/images/body/light/modules/module-m.png); background-repeat:repeat-x;">
+<div class="story-share" style="left:15px; top:8px;">
+<div class="static">
+ 
+<script type="text/javascript">
+                var act = new gigya.services.socialize.UserAction();
+                act.setTitle('TOLOnews 6pm News 19 April 2016');
+                act.setLinkBack('http://www.tolonews.com/en/video/24865-tolonews-6pm-news-19-april-2016');
+                act.setDescription("");
+                //  act.addActionLink("Watch this movie", "http://vimeo.com/24496773");
+                act.addMediaItem({ type: 'image', src: 'http://tolonews.com/demo/logo.png', href: 'http://www.nydailynews.com/new-york/ghost-holster-friendly-article-1.1068986' });
+                var showShareBarUI_params=
+                {
+                layout:'horizontal',
+                containerID: 'static',
+                shareButtons: [
+                { provider: 'Twitter',enableCount: 'true'},
+                { provider: 'Facebook-Like',action: 'recommend',tooltip: 'Recommend',enableCount: 'false'}
+                ],
+                userAction: act,
+                onLoad: onLoadHandler,
+                onSendDone: onSendDoneHandler
+                }
+                function onLoadHandler(event){
+                if(loginId.length > 0){
+                jQuery('input[id$="gigya.services.socialize.plugins.share.showShareUI_tbYourEmail"]').val(loginId);
+                }
+                }
+              // onSendDone event handler.
+                    function onSendDoneHandler(event){
+                    if (event.providers == 'email') { 
+                    // add this to email logger
+                    jQuery('.logger').empty();
+                    jQuery('.logger').append('<img src="/logger/p.gif?type=EMAILED&d=/2.169/2.1280&a=1.1068986"/>');
+                    }
+                    else{
+                    // add this to share logger
+                    jQuery('.logger').empty();
+                    jQuery('.logger').append('<img src="/logger/p.gif?type=SOCIALNETWORK&d=/2.169/2.1280&a=1.1068986"/>');
+                    }
+                    }
+            </script>
+<div id="static"></div>
+<script type="text/javascript">
+                gigya.services.socialize.showShareBarUI({},showShareBarUI_params);
+            </script>
+ 
+<style>#static{height:38px;}#static td{vertical-align:middle!important;}#static td td{vertical-align:middle!important;}#static .fb-like iframe{width:450px!important;}#static:after{content:".";display:block;height:0;clear:both;visibility:hidden;}</style>
+</div>
+<div class="dynamic">
+<div class="horizontal">
+<script type="text/javascript">
+            
+            jQuery(document).ready(function(){
+    detectScroll;
+    function detectScroll(){
+        if( ( jQuery(window).scrollTop() > ( jQuery(".story-share").position().top + jQuery(".story-share").height() ) ) && ( jQuery(window).width() > 1230 ) ){
+            jQuery(".vertical").show();
+        }else{
+            jQuery(".vertical").hide();
+        }
+    }
+    jQuery(window).bind('scroll', detectScroll);
+
+    jQuery(window).resize(function() {
+        if((jQuery(window).width() > 1230) && (jQuery(window).scrollTop() > (jQuery(".story-share").position().top + jQuery(".story-share").height()))){
+            jQuery(".vertical").show();
+        }else{
+            jQuery(".vertical").hide();
+        }
+    });
+        
+    jQuery("span.goto-comments").click(function(){ 
+        commentTop = jQuery("#story-comments").position().top;
+        jQuery('html,body').animate({ scrollTop: commentTop }, 500);
+    });
+    jQuery("span#post-comment").click(function(){ 
+        formTop = jQuery("#comment-form").position().top;
+        jQuery('html,body').animate({ scrollTop: formTop }, 500);
+    });
+});
+            
+            
+                var act = new gigya.services.socialize.UserAction();
+                //act.setUserMessage("This is the user message");
+                act.setTitle('TOLOnews 6pm News 19 April 2016');
+                act.setLinkBack('http://www.tolonews.com/en/video/24865-tolonews-6pm-news-19-april-2016');
+                act.setDescription("");
+                //  act.addActionLink("Watch this movie", "http://vimeo.com/24496773");
+                act.addMediaItem({ type: 'image', src: 'http://tolonews.com/demo/logo.png', href: 'http://www.nydailynews.com/new-york/ghost-holster-friendly-article-1.1068986' });
+                var showShareBarUI_params=
+                { 
+                containerID: 'horizontal',
+                shareButtons: 'Google-plusone,Stumbleupon,Tumblr, Digg, Reddit, Linkedin',
+                showCounts: 'none',
+                userAction: act,
+                onLoad: onLoadHandler,
+                onSendDone: onSendDoneHandler
+                }
+                
+                function onLoadHandler(event){
+                    if(loginId.length > 0){
+                        jQuery('input[id$="gigya.services.socialize.plugins.share.showShareUI_tbYourEmail"]').val(loginId);
+                    }
+                }
+                
+                // onSendDone event handler.
+                function onSendDoneHandler(event){
+                    if (event.providers == 'email') { 
+                        // add this to email logger
+                        jQuery('.logger').empty();
+                        jQuery('.logger').append('<img src="/logger/p.gif?type=EMAILED&d=/2.169/2.1280&a=1.1068986"/>');
+                    }
+
+                    else{
+                        // add this to share logger
+                        jQuery('.logger').empty();
+                        jQuery('.logger').append('<img src="/logger/p.gif?type=SOCIALNETWORK&d=/2.169/2.1280&a=1.1068986"/>');
+                    }
+                }
+            </script>
+<div id="horizontal"></div>
+ 
+<a target="new" href="http://www.tolonews.com/en/video/24865-tolonews-6pm-news-19-april-2016?tmpl=component&print=1&layout=default" class="story-print">Print</a>
+ 
+<script type="text/javascript">
+                gigya.services.socialize.showShareBarUI({},showShareBarUI_params);
+            </script>
+<style>#horizontal{height:38px;!important;}#horizontal td{vertical-align:top!important;direction:ltr;}#horizontal td td{vertical-align:middle!important;}</style>
+</div>
+<div class="vertical">
+<div>
+<div>
+<div align="left" dir="ltr">
+<script type="text/javascript">
+                            var act = new gigya.services.socialize.UserAction();
+                            act.setTitle('TOLOnews 6pm News 19 April 2016');
+                            act.setLinkBack('http://www.tolonews.com/en/video/24865-tolonews-6pm-news-19-april-2016');
+                            act.setDescription("Police officers have been warned of a new threat to their lives \u2014 a holster that allows criminals to hide their guns and even fire through their clothing, police sources said."); 
+                            act.addMediaItem({ type: 'image', src: 'http://tolonews.com/demo/logo.png', href: 'http://www.nydailynews.com/new-york/ghost-holster-friendly-article-1.1068986' });
+                            var showShareBarUI_params=
+                            {   
+                            layout:'vertical',
+                            containerID: 'vertical',
+                            shareButtons: [
+                            { provider: 'Facebook-Like',action:'recommend',tooltip: 'Recommend'},
+                            { provider: 'Twitter',enableCount: 'true'},
+                            { provider: 'Google-plusone'},
+                            { provider: 'Stumbleupon'},
+                            { provider: 'Tumblr'},
+                            { provider: 'Digg'},
+                            { provider: 'Linkedin'}, 
+                            { provider: 'Reddit'}
+                            ],
+                            showCounts: 'top',
+                            userAction: act,
+                            onLoad: onLoadHandler,
+                            onSendDone: onSendDoneHandler
+                            }
+                            
+                            function onLoadHandler(event){
+                                if(loginId.length > 0){
+                                    jQuery('input[id$="gigya.services.socialize.plugins.share.showShareUI_tbYourEmail"]').val(loginId);
+                                }
+                            }
+                            
+                            // onSendDone event handler.
+                            function onSendDoneHandler(event){
+                            if (event.providers == 'email') { 
+                            // add this to email logger
+                            jQuery('.logger').empty();
+                            jQuery('.logger').append('<img src="/logger/p.gif?type=EMAILED&d=/2.169/2.1280&a=1.1068986"/>');
+                            }
+                            else{
+                            // add this to log
+                            jQuery('.logger').empty();
+                            jQuery('.logger').append('<img src="/logger/p.gif?type=SOCIALNETWORK&d=/2.169/2.1280&a=1.1068986"/>');
+                            }
+                            }
+                        </script>
+<div id="vertical"></div>
+ 
+<a target="new" href="http://www.tolonews.com/en/video/24865-tolonews-6pm-news-19-april-2016?tmpl=component&print=1&layout=default" class="story-print">Print</a>
+ 
+<script type="text/javascript">
+                            gigya.services.socialize.showShareBarUI({},showShareBarUI_params);
+                        </script>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+ 
+<div class="rt-surround"><div class="rt-surround2"><div class="rt-surround3">
+<div id="rt-main-surround">
+<div id="rt-main" class="mb9-sa3">
+<div class="rt-main-inner">
+<div class="rt-grid-9 ">
+<div class="rt-block">
+<div class="default">
+<div class="rt-module-surround">
+<div class="rt-module-top"><div class="rt-module-top2"><div class="rt-module-top3"></div></div></div>
+<div class="rt-module-inner">
+<div id="rt-mainbody">
+<div class="rt-joomla ">
+<div class="rt-article">
+<p class="rt-article-cat">
+<span class="rt-section">
+Videos - </span>
+<span class="rt-category">
+6pm News Bulletin </span>
+</p>
+<div class="rt-headline"><h1 class="rt-article-title"><a href="/en/video/24865-tolonews-6pm-news-19-april-2016">TOLOnews 6pm News 19 April 2016</a></h1> </div>
+<div class="rt-articleinfo">
+<span class="rt-date-posted">
+Tuesday, 19 April 2016 20:41 </span>
+<span class="rt-author">
+Written by Faridullah Hussainkhail </span>
+</div>
+<p><img src="/TOLOnews_photo/shuja-19-april-16.jpg" alt="shuja-19-april-16"/><em><strong>Top news in this Bulletin:</strong></em></p>
+<p><strong>Acting Governor of Balkh province, Atta Mohammad Noor, said that differences between leaders of the National Unity Government (NUG) – namely President Ashraf Ghani and CEO Abdullah Abdullah— have paved the ground for mounting insecurity.</strong></p>
+<p><em><strong>To watch the whole news bulletin, click here:</strong></em></p>
+<p>
+ 
+<span class="avPlayerContainer">
+<span style="width:400px;" class="avPlayerSubContainer avPlayerSubContainerClean">
+<span id="AVPlayerID_097d3d07" class="avPlayerBlock">
+<object type="application/x-shockwave-flash" style="width:400px;height:300px;" data="http://www.youtube.com/v/dxPaItIAwrk&amp;hl=en&amp;fs=1" title="JoomlaWorks AllVideos Player">
+<param name="movie" value="http://www.youtube.com/v/dxPaItIAwrk&amp;hl=en&amp;fs=1"/>
+<param name="quality" value="high"/>
+<param name="wmode" value="transparent"/>
+<param name="bgcolor" value="#010101"/>
+<param name="allowfullscreen" value="true"/>
+<param name="allowscriptaccess" value="always"/>
+</object>
+</span>
+</span>
+</span>
+ 
+</p>
+<p>Hundreds of worried relatives gathered outside Kabul hospitals on Tuesday desperate for news of loved ones following the deadly suicide bombing earlier in the day.</p>
+</div>
+</div>
+</div>
+<div class="clear"></div>
+</div>
+<div class="rt-module-bottom"><div class="rt-module-bottom2"><div class="rt-module-bottom3"></div></div></div>
+</div>
+</div>
+</div>
+<div id="rt-content-bottom">
+<div class="rt-grid-9 rt-alpha rt-omega">
+<div class="language">
+<div class="rt-block">
+<div class="rt-module-surround">
+<div class="rt-module-top11 ">
+<div class="rt-module-top21 ">
+<div class="rt-module-top31 ">
+</div></div></div>
+<div class="rt-module-inner1 ">
+<div class="module-content">
+<div class="google-horizontal" style="margin-left: -5px;" align="center">  <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script><ins class="adsbygoogle" style="display: inline-block; width: 728px; height: 90px;" data-ad-client="ca-pub-7997130468567160" data-ad-slot="7481989195"></ins><script>
+(adsbygoogle = window.adsbygoogle || []).push({});
+</script></div> </div>
+</div>
+<div class="rt-module-bottom1 ">
+<div class="rt-module-bottom21 ">
+<div class="rrt-module-bottom31 ">
+</div></div></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="rt-grid-3 ">
+<div id="rt-sidebar-a">
+<div class="live">
+<div class="rt-block">
+<div class="rt-module-surround">
+<div class="rt-module-top  ">
+<div class="rt-module-top2  ">
+<div class="rt-module-top3  ">
+</div></div></div>
+<div class="rt-module-inner  ">
+<div class="module-title  ">
+<h2 class="title">Nightly News</h2></div>
+<div class="clear"></div>
+<div class="module-content">
+<iframe title="Simple youtube module by JoomShaper.com" id="sp-simple-youtube144" type="text/html" width="210" height="152" src="http://www.youtube.com/embed/skKzODJWAiA?wmode=Opaque"frameborder="0" allowFullScreen></iframe>
+	
+						</div>
+					</div>
+					<div class="rt-module-bottom ">
+					<div class="rt-module-bottom2  ">
+					<div class="rt-module-bottom3  ">
+					</div></div></div>
+				</div>
+            </div>
+                </div>
+		
+	                    <div class="rt-block">
+				<div class="rt-module-surround">
+					<div class="rt-module-top  ">
+					
+					<div class="rt-module-top2  ">
+					<div class="rt-module-top3  ">
+					</div></div></div>
+					<div class="rt-module-inner  ">
+	                							<div class="module-content">
+		                <div><a href="http://www.tolonews.com/en/tolonews-live-stream" style="border: none;"><img style="display: block; margin-left: auto; margin-right: auto;" src="/images/social/tolonews_live_Streaming_new_english_v1.png" alt="TOLOnews Live" width="202" height="152" /></a></div>						</div>
+					</div>
+					<div class="rt-module-bottom ">
+					<div class="rt-module-bottom2  ">
+					<div class="rt-module-bottom3  ">
+					</div></div></div>
+				</div>
+            </div>
+        	
+	                <div class="dw-ads">
+                    <div class="rt-block">
+				<div class="rt-module-surround">
+					<div class="rt-module-top  ">
+					
+					<div class="rt-module-top2  ">
+					<div class="rt-module-top3  ">
+					</div></div></div>
+					<div class="rt-module-inner  ">
+	                							<div class="module-content">
+		                <p><iframe src="http://partner.dw.com/syndication/feeds/CB_Tolonews_Dar_migrationquest.17477-cb.html"
+               width="220"
+               height="620"
+               frameborder="0"
+               allowTransparency="true">
+               Your browser does not support inline frames or is currently configured not to display inline frames.
+</iframe> </p>						</div>
+					</div>
+					<div class="rt-module-bottom ">
+					<div class="rt-module-bottom2  ">
+					<div class="rt-module-bottom3  ">
+					</div></div></div>
+				</div>
+            </div>
+                </div>
+		
+	                <div class="google-ads">
+                    <div class="rt-block">
+				<div class="rt-module-surround">
+					<div class="rt-module-top  ">
+					
+					<div class="rt-module-top2  ">
+					<div class="rt-module-top3  ">
+					</div></div></div>
+					<div class="rt-module-inner  ">
+	                							<div class="module-content">
+		                <div align="center"><script type="text/javascript"><!--
+google_ad_client = "pub-7997130468567160";
+/* 160x600, created 11/4/10 */
+google_ad_slot = "3385157006";
+google_ad_width = 160;
+google_ad_height = 600;
+//-->
+</script>
+<script type="text/javascript" src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
+</script></div>						</div>
+					</div>
+					<div class="rt-module-bottom ">
+					<div class="rt-module-bottom2  ">
+					<div class="rt-module-bottom3  ">
+					</div></div></div>
+				</div>
+            </div>
+                </div>
+		
+	                    <div class="rt-block">
+				<div class="rt-module-surround">
+					<div class="rt-module-top  ">
+					
+					<div class="rt-module-top2  ">
+					<div class="rt-module-top3  ">
+					</div></div></div>
+					<div class="rt-module-inner  ">
+	                							<div class="module-title  " >
+						<h2 class="title">TOLOnews Poll</h2></div>
+						<div class="clear"></div>
+		                						<div class="module-content">
+		                
+<h4 class="rt-polltitle">
+	What is your view on the future of the peace talks with Taliban?</h4>
+<form action="index.php" method="post" name="form2" class="rt-poll">
+	<fieldset>
+				<div class="rt-pollrow">
+			<input type="radio" name="voteid" id="voteid637" value="637" alt="637" />
+			<label for="voteid637">
+				I am hopeful on the talks			</label>
+		</div>
+				<div class="rt-pollrow">
+			<input type="radio" name="voteid" id="voteid638" value="638" alt="638" />
+			<label for="voteid638">
+				The peace talks will not bring any change			</label>
+		</div>
+				<div class="rt-pollrow">
+			<input type="radio" name="voteid" id="voteid639" value="639" alt="639" />
+			<label for="voteid639">
+				The talks are useless			</label>
+		</div>
+			</fieldset>
+	<div class="rt-pollbuttons">
+		<div class="readon">
+			<input type="submit" name="task_button" class="button" value="Vote" />
+		</div>
+		<div class="readon">
+			<input type="button" name="option" class="button" value="Results" onclick="document.location.href='/en/component/poll/54-what-is-your-view-on-the-future-of-the-peace-talks-with-taliban'" />
+		</div>
+	</div>
+
+	<input type="hidden" name="option" value="com_poll" />
+	<input type="hidden" name="task" value="vote" />
+	<input type="hidden" name="id" value="54" />
+	<input type="hidden" name="b2b725ed171d67440e0fdc796cc34d6d" value="1" /></form>
+						</div>
+					</div>
+					<div class="rt-module-bottom ">
+					<div class="rt-module-bottom2  ">
+					<div class="rt-module-bottom3  ">
+					</div></div></div>
+				</div>
+            </div>
+        	
+	                    <div class="rt-block">
+				<div class="rt-module-surround">
+					<div class="rt-module-top  ">
+					
+					<div class="rt-module-top2  ">
+					<div class="rt-module-top3  ">
+					</div></div></div>
+					<div class="rt-module-inner  ">
+	                							<div class="module-content">
+		                
+<div id="dm_tabs_1">
+  <ul class="dm_menu_1">
+        <li class="dm_menu_item_1"><a href="#" rel="dm_tab_1_1" class="dm_selected">Facebook</a></li>
+        <li class="dm_menu_item_1"><a href="#" rel="dm_tab_1_2">Twitter</a></li>
+      </ul>
+</div>
+<br style="clear:left;" />
+<div id="dm_container_1">
+    <div id="dm_tab_1_1" class="dm_tabcontent">
+    <div class="moduletable">
+      
+<!-- /mod_php version 1.0.0.Beta2 (c) www.fijiwebdesign.com -->
+ <div id="fb-root"></div>
+<script>(function(d, s, id) {
+  var js, fjs = d.getElementsByTagName(s)[0];
+  if (d.getElementById(id)) return;
+  js = d.createElement(s); js.id = id;
+  js.src = "//connect.facebook.net/en_US/all.js#xfbml=1";
+  fjs.parentNode.insertBefore(js, fjs);
+}(document, 'script', 'facebook-jssdk'));</script>
+
+<div class="fb-like-box" data-href="http://www.facebook.com/TOLOnews" data-width="250" data-height="300" data-show-faces="false" data-stream="true" data-show-border="false" data-header="true"></div>
+
+<!-- mod_php version 1.0.0.Beta2/ -->
+    </div>
+  </div>
+    <div id="dm_tab_1_2" class="dm_tabcontent">
+    <div class="moduletable-hilite">
+      
+<!-- /mod_php version 1.0.0.Beta2 (c) www.fijiwebdesign.com -->
+ <a class="twitter-timeline"  href="https://twitter.com/TOLOnews"  data-widget-id="344686183953076224">Tweets by @TOLOnews</a>
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+
+
+<!-- mod_php version 1.0.0.Beta2/ -->
+    </div>
+  </div>
+  </div>						</div>
+					</div>
+					<div class="rt-module-bottom ">
+					<div class="rt-module-bottom2  ">
+					<div class="rt-module-bottom3  ">
+					</div></div></div>
+				</div>
+            </div>
+        	
+	                    <div class="rt-block">
+				<div class="rt-module-surround">
+					<div class="rt-module-top  ">
+					
+					<div class="rt-module-top2  ">
+					<div class="rt-module-top3  ">
+					</div></div></div>
+					<div class="rt-module-inner  ">
+	                							<div class="module-title  " >
+						<h2 class="title">RSS</h2></div>
+						<div class="clear"></div>
+		                						<div class="module-content">
+		                <div style="text-align:center" class="bcarss">
+	<div style="text-align:center" class="bcarss_message">
+		    </div>
+<div style="text-align:center" class="bcarss_feed"><a href="http://tolonews.com/index.php?option=com_ninjarsssyndicator&amp;feed_id=1&amp;format=raw"><img src="http://tolonews.com/components/com_ninjarsssyndicator/assets/images/buttons/rss-tolonews-1278782977.png" alt="TOLOnews.com RSS Feed" title="TOLOnews.com RSS Feed" /></a></div></div>
+						</div>
+					</div>
+					<div class="rt-module-bottom ">
+					<div class="rt-module-bottom2  ">
+					<div class="rt-module-bottom3  ">
+					</div></div></div>
+				</div>
+            </div>
+        	
+	
+                </div>
+            </div>
+
+                    <div class="clear"></div>
+                </div>
+            </div>
+					 													<div id="rt-mainbottom">
+							<div class="rt-grid-6 rt-alpha">
+                        <div class="rt-block">
+				<div class="rt-module-surround">
+					<div class="rt-module-top  ">
+					
+					<div class="rt-module-top2  ">
+					<div class="rt-module-top3  ">
+					</div></div></div>
+					<div class="rt-module-inner  ">
+	                							<div class="module-title  " >
+						<h2 class="title">Latest News</h2></div>
+						<div class="clear"></div>
+		                						<div class="module-content">
+		                <ul class="latestnews">
+	<li class="latestnews">
+		<a href="/en/mehwar/25208-mehwar-tutap-protestors-set-deadline-as-ghani-pledges-review" class="latestnews">
+			MEHWAR: TUTAP Protestors Set Deadline As Ghani Pledges Review</a>
+	</li>
+	<li class="latestnews">
+		<a href="/en/mehwar/25207-mehwar-report-speaks-of-confusion-among-us-soldiers-afghan-mission" class="latestnews">
+			MEHWAR: Report Speaks Of Confusion Among U.S Soldiers' Afghan Mission</a>
+	</li>
+	<li class="latestnews">
+		<a href="/en/afghanistan/25206-ghani-leaves-kabul-for-two-day-visit-to-tajikistan" class="latestnews">
+			Ghani Leaves Kabul for Two Day Visit to Tajikistan</a>
+	</li>
+	<li class="latestnews">
+		<a href="/en/fara-khabar/25205-farakhabar-senior-officials-accused-of-activities-outside-of-their-authority" class="latestnews">
+			FARAKHABAR: Senior Officials Accused Of Activities Outside Of Their Authority</a>
+	</li>
+	<li class="latestnews">
+		<a href="/en/video/25204-tolonews-6pm-news-09-may-2016" class="latestnews">
+			TOLOnews 6pm News 09 May 2016</a>
+	</li>
+	<li class="latestnews">
+		<a href="/en/afghanistan/25203-noor-criticizes-govt-for-not-consulting-on-executions" class="latestnews">
+			Noor Criticizes Govt For Not Consulting On Executions</a>
+	</li>
+	<li class="latestnews">
+		<a href="/en/afghanistan/25202-tutap-protestors-set-deadline-as-ghani-pledges-review" class="latestnews">
+			TUTAP Protestors Set Deadline As Ghani Pledges Review</a>
+	</li>
+	<li class="latestnews">
+		<a href="/en/afghanistan/25201-report-speaks-of-confusion-among-us-soldiers-afghan-mission" class="latestnews">
+			Report Speaks Of Confusion Among U.S Soldiers' Afghan Mission</a>
+	</li>
+	<li class="latestnews">
+		<a href="/en/afghanistan/25200-calls-mount-for-more-executions" class="latestnews">
+			Calls Mount For More Executions</a>
+	</li>
+	<li class="latestnews">
+		<a href="/en/afghanistan/25199-through-the-window-of-a-kabul-widows-mud-house" class="latestnews">
+			Through The Window Of A Kabul Widow's Mud House</a>
+	</li>
+</ul>						</div>
+					</div>
+					<div class="rt-module-bottom ">
+					<div class="rt-module-bottom2  ">
+					<div class="rt-module-bottom3  ">
+					</div></div></div>
+				</div>
+            </div>
+        	
+	
+</div>
+<div class="rt-grid-6 rt-omega">
+                        <div class="rt-block">
+				<div class="rt-module-surround">
+					<div class="rt-module-top  ">
+					
+					<div class="rt-module-top2  ">
+					<div class="rt-module-top3  ">
+					</div></div></div>
+					<div class="rt-module-inner  ">
+	                							<div class="module-title  " >
+						<h2 class="title">Most Popular</h2></div>
+						<div class="clear"></div>
+		                						<div class="module-content">
+		                <ul class="mostread">
+	<li class="mostread">
+		<a href="/en/afghanistan/25179-taliban-storm-police-check-post-on-outskirts-of-kabul" class="mostread">
+			Taliban Storm Police Check Post On Outskirts Of Kabul</a>
+	</li>
+	<li class="mostread">
+		<a href="/en/afghanistan/25173-six-terrorists-executed-in-afghanistan" class="mostread">
+			Six Terrorists Executed In Afghanistan</a>
+	</li>
+	<li class="mostread">
+		<a href="/en/afghanistan/25177-afghan-officials-release-identities-of-insurgents-executed" class="mostread">
+			Afghan Officials Release Identities Of Insurgents Executed</a>
+	</li>
+	<li class="mostread">
+		<a href="/en/afghanistan/25166-over-200-suspected-insurgents-arrested-in-parwan" class="mostread">
+			Over 200 Suspected Insurgents Arrested In Parwan</a>
+	</li>
+	<li class="mostread">
+		<a href="/en/afghanistan/25153-tear-down-walls-against-refugees-pope-francis-tells-eu" class="mostread">
+			Tear Down Walls Against Refugees, Pope Francis Tells EU</a>
+	</li>
+	<li class="mostread">
+		<a href="/en/afghanistan/25159-critics-push-ghani-to-start-implementing-his-promises" class="mostread">
+			Critics Push Ghani To Start Implementing His Promises</a>
+	</li>
+	<li class="mostread">
+		<a href="/en/afghanistan/25172-50-people-killed-in-ghazni-traffic-accident" class="mostread">
+			50 People Killed in Ghazni Traffic Accident</a>
+	</li>
+	<li class="mostread">
+		<a href="/en/afghanistan/25161-failure-to-eliminate-militants-would-be-a-historical-mistake-rabbani" class="mostread">
+			Failure To Eliminate Militants Would Be A Historical Mistake: Rabbani</a>
+	</li>
+	<li class="mostread">
+		<a href="/en/afghanistan/25162-lawmakers-divided-over-tutap-route" class="mostread">
+			Lawmakers Divided Over TUTAP Route</a>
+	</li>
+	<li class="mostread">
+		<a href="/en/afghanistan/25178-taliban-preparing-for-war-in-baghlan-troops" class="mostread">
+			Taliban Preparing For War In Baghlan: Troops</a>
+	</li>
+</ul>						</div>
+					</div>
+					<div class="rt-module-bottom ">
+					<div class="rt-module-bottom2  ">
+					<div class="rt-module-bottom3  ">
+					</div></div></div>
+				</div>
+            </div>
+        	
+	
+</div>
+
+							<div class="clear"></div>
+						</div>
+																							</div>
+										<div id="rt-copyright">
+					<div class="rt-grid-12 rt-alpha rt-omega">
+    		<div class="clear"></div>
+		<span class="copytext">TOLOnews.com</span>
+		
+                    <div class="rt-block">
+				<div class="rt-module-surround">
+					<div class="rt-module-top  ">
+					
+					<div class="rt-module-top2  ">
+					<div class="rt-module-top3  ">
+					</div></div></div>
+					<div class="rt-module-inner  ">
+	                							<div class="module-content">
+		                <table width="100%" border="0" cellpadding="0" cellspacing="1"><tr><td nowrap="nowrap"><span class="mainlevel"> &nbsp; </span><a href="http://www.tolonews.com/" class="mainlevel" >Home</a><span class="mainlevel"> &nbsp; </span><a href="http://tolonews.com/en/component/news_portal/?task=category&id=6" class="mainlevel" >News</a><span class="mainlevel"> &nbsp; </span><a href="http://tolonews.com/index.php?option=com_contact&view=contact&id=1%3Acontact-us&catid=22%3Acontact-us&Itemid=60" class="mainlevel" >Contact Us</a><span class="mainlevel"> &nbsp; </span><a href="/en/contest-rules" class="mainlevel" >Contest Rules</a><span class="mainlevel"> &nbsp; </span></td></tr></table>						</div>
+					</div>
+					<div class="rt-module-bottom ">
+					<div class="rt-module-bottom2  ">
+					<div class="rt-module-bottom3  ">
+					</div></div></div>
+				</div>
+            </div>
+        	
+	
+</div>
+						<div class="clear"></div>
+					</div>
+					<div class="rt-footer-bottom-wrap"><div class="rt-footer-bottom"><div class="rt-footer-bottom2"><div class="rt-footer-bottom3"></div></div></div></div>
+									</div></div></div>
+				<div class="rt-surround-bottom"><div class="rt-surround-bottom2"><div class="rt-surround-bottom3"></div></div></div>
+							</div>
+		</div>
+		
+
+<script type="text/javascript">
+    adroll_adv_id = "HAGC73UPU5HYDFHIBRGJIK";
+    adroll_pix_id = "F6AKNQTQYJBZZINX6TRNU6";
+    // adroll_email = "username@example.com"; // OPTIONAL: provide email to improve user identification
+    (function () {
+        var _onload = function(){
+            if (document.readyState && !/loaded|complete/.test(document.readyState)){setTimeout(_onload, 10);return}
+            if (!window.__adroll_loaded){__adroll_loaded=true;setTimeout(_onload, 50);return}
+            var scr = document.createElement("script");
+            var host = (("https:" == document.location.protocol) ? "https://s.adroll.com" : "http://a.adroll.com");
+            scr.setAttribute('async', 'true');
+            scr.type = "text/javascript";
+            scr.src = host + "/j/roundtrip.js";
+            ((document.getElementsByTagName('head') || [null])[0] ||
+                document.getElementsByTagName('script')[0].parentNode).appendChild(scr);
+        };
+        if (window.addEventListener) {window.addEventListener('load', _onload, false);}
+        else {window.attachEvent('onload', _onload)}
+    }());
+</script>
+
+
+	</body>
+</html>
+


### PR DESCRIPTION
When text has formatting, e.g., strong, b, em, tags in it the weightChildNodes in ArticleTextExtractor ignores data. This change uses all text under a p tag to calculate the child's weight score. Subsequently this improves identifying the main area of text. An additional test case has been created to show this working. 