### PR TITLE
Changes to handle multiple contiguous article elements

### DIFF
--- a/.idea/libraries/Maven__com_amazonaws_aws_java_sdk_core_1_11_69.xml
+++ b/.idea/libraries/Maven__com_amazonaws_aws_java_sdk_core_1_11_69.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.amazonaws:aws-java-sdk-core:1.11.69">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/amazonaws/aws-java-sdk-core/1.11.69/aws-java-sdk-core-1.11.69.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/amazonaws/aws-java-sdk-core/1.11.69/aws-java-sdk-core-1.11.69-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/amazonaws/aws-java-sdk-core/1.11.69/aws-java-sdk-core-1.11.69-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__com_amazonaws_aws_java_sdk_kms_1_11_69.xml
+++ b/.idea/libraries/Maven__com_amazonaws_aws_java_sdk_kms_1_11_69.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.amazonaws:aws-java-sdk-kms:1.11.69">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/amazonaws/aws-java-sdk-kms/1.11.69/aws-java-sdk-kms-1.11.69.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/amazonaws/aws-java-sdk-kms/1.11.69/aws-java-sdk-kms-1.11.69-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/amazonaws/aws-java-sdk-kms/1.11.69/aws-java-sdk-kms-1.11.69-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__com_amazonaws_aws_java_sdk_s3_1_11_69.xml
+++ b/.idea/libraries/Maven__com_amazonaws_aws_java_sdk_s3_1_11_69.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.amazonaws:aws-java-sdk-s3:1.11.69">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/amazonaws/aws-java-sdk-s3/1.11.69/aws-java-sdk-s3-1.11.69.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/amazonaws/aws-java-sdk-s3/1.11.69/aws-java-sdk-s3-1.11.69-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/amazonaws/aws-java-sdk-s3/1.11.69/aws-java-sdk-s3-1.11.69-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__com_amazonaws_jmespath_java_1_11_69.xml
+++ b/.idea/libraries/Maven__com_amazonaws_jmespath_java_1_11_69.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.amazonaws:jmespath-java:1.11.69">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/amazonaws/jmespath-java/1.11.69/jmespath-java-1.11.69.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/amazonaws/jmespath-java/1.11.69/jmespath-java-1.11.69-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/amazonaws/jmespath-java/1.11.69/jmespath-java-1.11.69-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__com_fasterxml_jackson_core_jackson_annotations_2_6_0.xml
+++ b/.idea/libraries/Maven__com_fasterxml_jackson_core_jackson_annotations_2_6_0.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.fasterxml.jackson.core:jackson-annotations:2.6.0">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-annotations/2.6.0/jackson-annotations-2.6.0.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-annotations/2.6.0/jackson-annotations-2.6.0-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-annotations/2.6.0/jackson-annotations-2.6.0-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__com_fasterxml_jackson_core_jackson_core_2_6_6.xml
+++ b/.idea/libraries/Maven__com_fasterxml_jackson_core_jackson_core_2_6_6.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.fasterxml.jackson.core:jackson-core:2.6.6">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-core/2.6.6/jackson-core-2.6.6.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-core/2.6.6/jackson-core-2.6.6-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-core/2.6.6/jackson-core-2.6.6-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__com_fasterxml_jackson_core_jackson_databind_2_6_6.xml
+++ b/.idea/libraries/Maven__com_fasterxml_jackson_core_jackson_databind_2_6_6.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.fasterxml.jackson.core:jackson-databind:2.6.6">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-databind/2.6.6/jackson-databind-2.6.6.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-databind/2.6.6/jackson-databind-2.6.6-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-databind/2.6.6/jackson-databind-2.6.6-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__com_fasterxml_jackson_dataformat_jackson_dataformat_cbor_2_6_6.xml
+++ b/.idea/libraries/Maven__com_fasterxml_jackson_dataformat_jackson_dataformat_cbor_2_6_6.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.6.6">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.6.6/jackson-dataformat-cbor-2.6.6.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.6.6/jackson-dataformat-cbor-2.6.6-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.6.6/jackson-dataformat-cbor-2.6.6-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__commons_codec_commons_codec_1_9.xml
+++ b/.idea/libraries/Maven__commons_codec_commons_codec_1_9.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: commons-codec:commons-codec:1.9">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/commons-codec/commons-codec/1.9/commons-codec-1.9.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/commons-codec/commons-codec/1.9/commons-codec-1.9-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/commons-codec/commons-codec/1.9/commons-codec-1.9-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__commons_logging_commons_logging_1_1_3.xml
+++ b/.idea/libraries/Maven__commons_logging_commons_logging_1_1_3.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: commons-logging:commons-logging:1.1.3">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/commons-logging/commons-logging/1.1.3/commons-logging-1.1.3.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/commons-logging/commons-logging/1.1.3/commons-logging-1.1.3-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/commons-logging/commons-logging/1.1.3/commons-logging-1.1.3-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__joda_time_joda_time_2_8_1.xml
+++ b/.idea/libraries/Maven__joda_time_joda_time_2_8_1.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: joda-time:joda-time:2.8.1">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/joda-time/joda-time/2.8.1/joda-time-2.8.1.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/joda-time/joda-time/2.8.1/joda-time-2.8.1-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/joda-time/joda-time/2.8.1/joda-time-2.8.1-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__org_apache_httpcomponents_httpclient_4_5_2.xml
+++ b/.idea/libraries/Maven__org_apache_httpcomponents_httpclient_4_5_2.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.apache.httpcomponents:httpclient:4.5.2">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/apache/httpcomponents/httpclient/4.5.2/httpclient-4.5.2.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/apache/httpcomponents/httpclient/4.5.2/httpclient-4.5.2-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/apache/httpcomponents/httpclient/4.5.2/httpclient-4.5.2-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__org_apache_httpcomponents_httpcore_4_4_4.xml
+++ b/.idea/libraries/Maven__org_apache_httpcomponents_httpcore_4_4_4.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.apache.httpcomponents:httpcore:4.4.4">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/apache/httpcomponents/httpcore/4.4.4/httpcore-4.4.4.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/apache/httpcomponents/httpcore/4.4.4/httpcore-4.4.4-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/apache/httpcomponents/httpcore/4.4.4/httpcore-4.4.4-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__software_amazon_ion_ion_java_1_0_1.xml
+++ b/.idea/libraries/Maven__software_amazon_ion_ion_java_1_0_1.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: software.amazon.ion:ion-java:1.0.1">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/software/amazon/ion/ion-java/1.0.1/ion-java-1.0.1.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/software/amazon/ion/ion-java/1.0.1/ion-java-1.0.1-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/software/amazon/ion/ion-java/1.0.1/ion-java-1.0.1-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>de.jetwick</groupId>
     <artifactId>snacktory</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>1.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Snacktory</name>
@@ -76,12 +76,18 @@
     </build>
     <distributionManagement>
         <snapshotRepository>
-            <id>karussell_snapshots</id>
-            <url>https://github.com/karussell/mvnrepo/raw/master/snapshots</url>
+            <id>edu.gcu.repo</id>
+            <url>s3://gcu.repo/snapshot</url>
         </snapshotRepository>
         <repository>
-            <id>karussell_releases</id>
-            <url>https://github.com/karussell/mvnrepo/raw/master/releases/</url>
+            <id>edu.gcu.repo</id>
+            <url>s3://gcu.repo/release</url>
         </repository>
     </distributionManagement>
+    <repositories>
+        <repository>
+            <id>edu.gcu.repo</id>
+            <url>s3://gcu.repo/snapshot</url>
+        </repository>
+    </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,13 @@
                 </configuration>
             </plugin>
         </plugins>
+        <extensions>
+            <extension>
+                <groupId>org.kuali.maven.wagons</groupId>
+                <artifactId>maven-s3-wagon</artifactId>
+                <version>1.2.1</version>
+            </extension>
+        </extensions>
     </build>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -14,9 +14,15 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>1.7.5</slf4j.version>
+        <aws.sdk.version>1.11.69</aws.sdk.version>
     </properties>
     
-    <dependencies>        
+    <dependencies>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>${aws.sdk.version}</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,262 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<!--
+ | This is the configuration file for Maven. It can be specified at two levels:
+ |
+ |  1. User Level. This settings.xml file provides configuration for a single user,
+ |                 and is normally provided in ${user.home}/.m2/settings.xml.
+ |
+ |                 NOTE: This location can be overridden with the CLI option:
+ |
+ |                 -s /path/to/user/settings.xml
+ |
+ |  2. Global Level. This settings.xml file provides configuration for all Maven
+ |                 users on a machine (assuming they're all using the same Maven
+ |                 installation). It's normally provided in
+ |                 ${maven.home}/conf/settings.xml.
+ |
+ |                 NOTE: This location can be overridden with the CLI option:
+ |
+ |                 -gs /path/to/global/settings.xml
+ |
+ | The sections in this sample file are intended to give you a running start at
+ | getting the most out of your Maven installation. Where appropriate, the default
+ | values (values used when the setting is not specified) are provided.
+ |
+ |-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <!-- localRepository
+     | The path to the local repository maven will use to store artifacts.
+     |
+     | Default: ~/.m2/repository
+    <localRepository>/path/to/local/repo</localRepository>
+    -->
+
+    <!-- interactiveMode
+     | This will determine whether maven prompts you when it needs input. If set to false,
+     | maven will use a sensible default value, perhaps based on some other setting, for
+     | the parameter in question.
+     |
+     | Default: true
+    <interactiveMode>true</interactiveMode>
+    -->
+
+    <!-- offline
+     | Determines whether maven should attempt to connect to the network when executing a build.
+     | This will have an effect on artifact downloads, artifact deployment, and others.
+     |
+     | Default: false
+    <offline>false</offline>
+    -->
+
+    <!-- pluginGroups
+     | This is a list of additional group identifiers that will be searched when resolving plugins by their prefix, i.e.
+     | when invoking a command line like "mvn prefix:goal". Maven will automatically add the group identifiers
+     | "org.apache.maven.plugins" and "org.codehaus.mojo" if these are not already contained in the list.
+     |-->
+    <pluginGroups>
+        <!-- pluginGroup
+         | Specifies a further group identifier to use for plugin lookup.
+        <pluginGroup>com.your.plugins</pluginGroup>
+        -->
+    </pluginGroups>
+
+    <!-- proxies
+     | This is a list of proxies which can be used on this machine to connect to the network.
+     | Unless otherwise specified (by system property or command-line switch), the first proxy
+     | specification in this list marked as active will be used.
+     |-->
+    <proxies>
+        <!-- proxy
+         | Specification for one proxy, to be used in connecting to the network.
+         |
+        <proxy>
+          <id>optional</id>
+          <active>true</active>
+          <protocol>http</protocol>
+          <username>proxyuser</username>
+          <password>proxypass</password>
+          <host>proxy.host.net</host>
+          <port>80</port>
+          <nonProxyHosts>local.net|some.host.com</nonProxyHosts>
+        </proxy>
+        -->
+    </proxies>
+
+    <!-- servers
+     | This is a list of authentication profiles, keyed by the server-id used within the system.
+     | Authentication profiles can be used whenever maven must make a connection to a remote server.
+     |-->
+    <servers>
+        <server>
+            <id>edu.gcu.repo</id>
+            <username>AKIAII6AVLZ6FRXTJYAA</username>
+            <password>GdOZKXqDE+cZuNEGetK6xveKKIWWWkBxOEmM5fmE</password>
+        </server>
+        <!-- server
+         | Specifies the authentication information to use when connecting to a particular server, identified by
+         | a unique name within the system (referred to by the 'id' attribute below).
+         |
+         | NOTE: You should either specify username/password OR privateKey/passphrase, since these pairings are
+         |       used together.
+         |
+        <server>
+          <id>deploymentRepo</id>
+          <username>repouser</username>
+          <password>repopwd</password>
+        </server>
+        -->
+
+        <!-- Another sample, using keys to authenticate.
+        <server>
+          <id>siteServer</id>
+          <privateKey>/path/to/private/key</privateKey>
+          <passphrase>optional; leave empty if not used.</passphrase>
+        </server>
+        -->
+    </servers>
+
+    <!-- mirrors
+     | This is a list of mirrors to be used in downloading artifacts from remote repositories.
+     |
+     | It works like this: a POM may declare a repository to use in resolving certain artifacts.
+     | However, this repository may have problems with heavy traffic at times, so people have mirrored
+     | it to several places.
+     |
+     | That repository definition will have a unique id, so we can create a mirror reference for that
+     | repository, to be used as an alternate download site. The mirror site will be the preferred
+     | server for that repository.
+     |-->
+    <mirrors>
+        <!-- mirror
+         | Specifies a repository mirror site to use instead of a given repository. The repository that
+         | this mirror serves has an ID that matches the mirrorOf element of this mirror. IDs are used
+         | for inheritance and direct lookup purposes, and must be unique across the set of mirrors.
+         |
+        <mirror>
+          <id>mirrorId</id>
+          <mirrorOf>repositoryId</mirrorOf>
+          <name>Human Readable Name for this Mirror.</name>
+          <url>http://my.repository.com/repo/path</url>
+        </mirror>
+         -->
+    </mirrors>
+
+    <!-- profiles
+     | This is a list of profiles which can be activated in a variety of ways, and which can modify
+     | the build process. Profiles provided in the settings.xml are intended to provide local machine-
+     | specific paths and repository locations which allow the build to work in the local environment.
+     |
+     | For example, if you have an integration testing plugin - like cactus - that needs to know where
+     | your Tomcat instance is installed, you can provide a variable here such that the variable is
+     | dereferenced during the build process to configure the cactus plugin.
+     |
+     | As noted above, profiles can be activated in a variety of ways. One way - the activeProfiles
+     | section of this document (settings.xml) - will be discussed later. Another way essentially
+     | relies on the detection of a system property, either matching a particular value for the property,
+     | or merely testing its existence. Profiles can also be activated by JDK version prefix, where a
+     | value of '1.4' might activate a profile when the build is executed on a JDK version of '1.4.2_07'.
+     | Finally, the list of active profiles can be specified directly from the command line.
+     |
+     | NOTE: For profiles defined in the settings.xml, you are restricted to specifying only artifact
+     |       repositories, plugin repositories, and free-form properties to be used as configuration
+     |       variables for plugins in the POM.
+     |
+     |-->
+    <profiles>
+        <!-- profile
+         | Specifies a set of introductions to the build process, to be activated using one or more of the
+         | mechanisms described above. For inheritance purposes, and to activate profiles via <activatedProfiles/>
+         | or the command line, profiles have to have an ID that is unique.
+         |
+         | An encouraged best practice for profile identification is to use a consistent naming convention
+         | for profiles, such as 'env-dev', 'env-test', 'env-production', 'user-jdcasey', 'user-brett', etc.
+         | This will make it more intuitive to understand what the set of introduced profiles is attempting
+         | to accomplish, particularly when you only have a list of profile id's for debug.
+         |
+         | This profile example uses the JDK version to trigger activation, and provides a JDK-specific repo.
+        <profile>
+          <id>jdk-1.4</id>
+
+          <activation>
+            <jdk>1.4</jdk>
+          </activation>
+
+          <repositories>
+            <repository>
+              <id>jdk14</id>
+              <name>Repository for JDK 1.4 builds</name>
+              <url>http://www.myhost.com/maven/jdk14</url>
+              <layout>default</layout>
+              <snapshotPolicy>always</snapshotPolicy>
+            </repository>
+          </repositories>
+        </profile>
+        -->
+
+        <!--
+         | Here is another profile, activated by the system property 'target-env' with a value of 'dev',
+         | which provides a specific path to the Tomcat instance. To use this, your plugin configuration
+         | might hypothetically look like:
+         |
+         | ...
+         | <plugin>
+         |   <groupId>org.myco.myplugins</groupId>
+         |   <artifactId>myplugin</artifactId>
+         |
+         |   <configuration>
+         |     <tomcatLocation>${tomcatPath}</tomcatLocation>
+         |   </configuration>
+         | </plugin>
+         | ...
+         |
+         | NOTE: If you just wanted to inject this configuration whenever someone set 'target-env' to
+         |       anything, you could just leave off the <value/> inside the activation-property.
+         |
+        <profile>
+          <id>env-dev</id>
+
+          <activation>
+            <property>
+              <name>target-env</name>
+              <value>dev</value>
+            </property>
+          </activation>
+
+          <properties>
+            <tomcatPath>/path/to/tomcat/instance</tomcatPath>
+          </properties>
+        </profile>
+        -->
+    </profiles>
+
+    <!-- activeProfiles
+     | List of profiles that are active for all builds.
+     |
+    <activeProfiles>
+      <activeProfile>alwaysActiveProfile</activeProfile>
+      <activeProfile>anotherAlwaysActiveProfile</activeProfile>
+    </activeProfiles>
+    -->
+</settings>

--- a/src/test/java/de/jetwick/snacktory/ArticleTextExtractorTest.java
+++ b/src/test/java/de/jetwick/snacktory/ArticleTextExtractorTest.java
@@ -36,6 +36,14 @@ public class ArticleTextExtractorTest {
     }
 
     @Test
+    public void testDataTrumpElection() throws Exception {
+//        JResult res = extractor.extractContent(readFileAsString("trump_election_protest.html"));
+        JResult res = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("trump_election_protest.html")));
+        assertEquals("‘Not Our President’: Protests Spread After Donald Trump’s Election - The New York Times", res.getTitle());
+        assertTrue(res.getText(), res.getText().startsWith("Thousands of people across the country marched, shut down highways, burned effigies and shouted angry slogans on Wednesday night to protest the election of Donald J. Trump as president."));
+    }
+
+    @Test
     public void testData2() throws Exception {
         // http://benjaminste.in/post/1223476561/hey-guys-whatcha-doing
         JResult res = extractor.extractContent(readFileAsString("test_data/2.html"));

--- a/src/test/resources/de/jetwick/snacktory/trump_election_protest.html
+++ b/src/test/resources/de/jetwick/snacktory/trump_election_protest.html
@@ -1,0 +1,2966 @@
+
+<!DOCTYPE html>
+<!--[if (gt IE 9)|!(IE)]> <!--> <html lang="en" class="no-js section-us format-medium tone-news app-article page-theme-standard has-top-ad type-size-small has-large-lede" itemid="https://www.nytimes.com/2016/11/10/us/trump-election-protests.html" itemtype="http://schema.org/NewsArticle"  itemscope xmlns:og="http://opengraphprotocol.org/schema/"> <!--<![endif]-->
+<!--[if IE 9]> <html lang="en" class="no-js ie9 lt-ie10 section-us format-medium tone-news app-article page-theme-standard has-top-ad type-size-small has-large-lede" xmlns:og="http://opengraphprotocol.org/schema/"> <![endif]-->
+<!--[if IE 8]> <html lang="en" class="no-js ie8 lt-ie10 lt-ie9 section-us format-medium tone-news app-article page-theme-standard has-top-ad type-size-small has-large-lede" xmlns:og="http://opengraphprotocol.org/schema/"> <![endif]-->
+<!--[if (lt IE 8)]> <html lang="en" class="no-js lt-ie10 lt-ie9 lt-ie8 section-us format-medium tone-news app-article page-theme-standard has-top-ad type-size-small has-large-lede" xmlns:og="http://opengraphprotocol.org/schema/"> <![endif]-->
+<head>
+    <title>‘Not Our President’: Protests Spread After Donald Trump’s Election - The New York Times</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+    <link rel="shortcut icon" href="https://static01.nyt.com/favicon.ico" />
+    <link rel="apple-touch-icon-precomposed" sizes="144×144" href="https://static01.nyt.com/images/icons/ios-ipad-144x144.png" />
+    <link rel="apple-touch-icon-precomposed" sizes="114×114" href="https://static01.nyt.com/images/icons/ios-iphone-114x144.png" />
+    <link rel="apple-touch-icon-precomposed" href="https://static01.nyt.com/images/icons/ios-default-homescreen-57x57.png" />
+    <meta name="sourceApp" content="nyt-v5" />
+    <meta id="applicationName" name="applicationName" content="article" />
+    <meta id="foundation-build-id" name="foundation-build-id" content="" />
+    <link rel="canonical" href="https://www.nytimes.com/2016/11/10/us/trump-election-protests.html" />
+    <link rel="alternate" media="only screen and (max-width: 640px)" href="http://mobile.nytimes.com/2016/11/10/us/trump-election-protests.html" />
+    <link rel="alternate" media="handheld" href="http://mobile.nytimes.com/2016/11/10/us/trump-election-protests.html" />
+    <link rel="amphtml" href="https://mobile.nytimes.com/2016/11/10/us/trump-election-protests.amp.html" />
+    <meta property="al:android:url" content="nytimes://reader/id/100000004760134" />
+    <meta property="al:android:package" content="com.nytimes.android" />
+    <meta property="al:android:app_name" content="NYTimes" />
+    <meta name="twitter:app:name:googleplay" content="NYTimes" />
+    <meta name="twitter:app:id:googleplay" content="com.nytimes.android" />
+    <meta name="twitter:app:url:googleplay" content="nytimes://reader/id/100000004760134" />
+    <link rel="alternate" href="android-app://com.nytimes.android/nytimes/reader/id/100000004760134" />
+    <meta property="al:iphone:url" content="nytimes://www.nytimes.com/2016/11/10/us/trump-election-protests.html" />
+    <meta property="al:iphone:app_store_id" content="284862083" />
+    <meta property="al:iphone:app_name" content="NYTimes" />
+    <meta property="al:ipad:url" content="nytimes://www.nytimes.com/2016/11/10/us/trump-election-protests.html" />
+    <meta property="al:ipad:app_store_id" content="357066198" />
+    <meta property="al:ipad:app_name" content="NYTimes" />
+    <meta name="robots" content="noarchive" />
+    <meta itemprop="alternativeHeadline" name="hdl_p" content="‘Not Our President’: Protests Spread" />
+    <meta name="channels" content="" />
+    <meta itemprop="description" name="description" content="Demonstrators marched through Manhattan toward Trump Tower, and similar protests took place in other cities and on college campuses across the country." />
+    <meta name="genre" itemprop="genre" content="News" />
+    <meta itemprop="identifier" name="articleid" content="100000004760134" />
+    <meta itemprop="usageTerms" name="usageTerms" content="http://www.nytimes.com/content/help/rights/sale/terms-of-sale.html" />
+    <meta itemprop="inLanguage" content="en-US" />
+    <meta name="hdl" content="‘Not Our President’: Protests Spread After Donald Trump’s Election" />
+    <meta name="col" content="" id="column-name" />
+    <meta name="pdate" content="20161109" />
+    <meta name="utime" content="20170228080206" />
+    <meta name="ptime" content="20161109211306" />
+    <meta name="DISPLAYDATE" content="Nov. 9, 2016" />
+    <meta name="dat" content="Nov. 9, 2016" />
+    <meta name="lp" content="Demonstrators marched through Manhattan toward Trump Tower, and similar protests took place in other cities and on college campuses across the country." />
+    <meta name="msapplication-starturl" content="http://www.nytimes.com" />
+    <meta name="cre" content="The New York Times" />
+    <meta name="slug" content="10xp-protests" />
+    <meta property="article:collection" content="https://static01.nyt.com/services/json/sectionfronts/us/index.jsonp" />
+    <meta name="sectionfront_jsonp" content="https://static01.nyt.com/services/json/sectionfronts/us/index.jsonp" />
+    <meta property="og:url" content="https://www.nytimes.com/2016/11/10/us/trump-election-protests.html" />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="‘Not Our President’: Protests Spread After Donald Trump’s Election" />
+    <meta property="og:description" content="Demonstrators marched through Manhattan toward Trump Tower, and similar protests took place in other cities and on college campuses across the country." />
+    <meta property="article:published" itemprop="datePublished" content="2016-11-09T21:13:06-05:00" />
+    <meta property="article:modified" itemprop="dateModified" content="2017-02-28T08:02:06-05:00" />
+    <meta property="article:section" itemprop="articleSection" content="U.S." />
+    <meta property="article:section-taxonomy-id" itemprop="articleSection" content="23FD6C8B-62D5-4CEA-A331-6C2A9A1223BE" />
+    <meta property="article:section_url" content="https://www.nytimes.com/section/us" />
+    <meta property="article:top-level-section" content="us" />
+    <meta property="fb:app_id" content="9869919170" />
+    <meta name="twitter:site" value="@nytimes" />
+    <meta property="twitter:url" content="https://www.nytimes.com/2016/11/10/us/trump-election-protests.html" />
+    <meta property="twitter:title" content="‘Not Our President’: Protests Spread After Donald Trump’s Election" />
+    <meta property="twitter:description" content="Demonstrators marched through Manhattan toward Trump Tower, and similar protests took place in other cities and on college campuses across the country." />
+    <meta name="author" content="Christopher Mele and Annie Correal" />
+    <meta name="tone" content="news" id="article-tone" />
+    <meta name="byl" content="By CHRISTOPHER MELE and ANNIE CORREAL" />
+    <meta name="PT" content="article" />
+    <meta name="CG" content="us" />
+    <meta name="SCG" content="" />
+    <meta name="PST" content="News" />
+    <meta name="tom" content="News" />
+    <meta name="edt" content="NewYork" />
+    <meta property="og:image" content="https://static01.nyt.com/images/2016/11/11/us/11attack2_xp/11attack2_xp-facebookJumbo.jpg" />
+    <meta property="twitter:image:alt" content="A pro-Trump supporter, right, attacked an anti-Trump protester at Lee Circle after the protester grabbed his Trump flag from the truck in New Orleans, on Wednesday." />
+    <meta property="twitter:image" content="https://static01.nyt.com/images/2016/11/11/us/11attack2_xp/11attack2_xp-thumbLarge.jpg" />
+    <meta name="twitter:card" value="summary" />
+    <meta property="article:author" content="https://www.nytimes.com/by/christopher-mele" />
+    <meta property="article:author" content="https://www.nytimes.com/by/annie-correal" />
+    <meta property="article:tag" content="Presidential Election of 2016" />
+    <meta name="des" content="Presidential Election of 2016" />
+    <meta property="article:tag" content="Demonstrations, Protests and Riots" />
+    <meta name="des" content="Demonstrations, Protests and Riots" />
+    <meta property="article:tag" content="Trump, Donald J" />
+    <meta name="per" content="Trump, Donald J" />
+    <meta name="keywords" content="Presidential Election of 2016,Demonstrations  Protests and Riots,Trump  Donald J" />
+    <meta name="news_keywords" content="2016 Presidential Election,Civil Unrest,Donald Trump" />
+    <meta name="thumbnail_150" content="https://static01.nyt.com/images/2016/11/11/us/11attack2_xp/11attack2_xp-thumbLarge.jpg" />
+    <meta name="thumbnail_150_height" content="150" />
+    <meta name="thumbnail_150_width" content="150" />
+    <meta itemprop="thumbnailUrl" name="thumbnail" content="https://static01.nyt.com/images/2016/11/11/us/11attack2_xp/11attack2_xp-thumbStandard.jpg" />
+    <meta name="thumbnail_height" content="75" />
+    <meta name="thumbnail_width" content="75" />
+    <meta name="video:playerId" content="2640832222001" />
+    <meta name="video:noShareToolsPlayerId" content="3692909326001" />
+    <meta name="video:publisherId" content="1749339200" />
+    <meta name="video:publisherReadToken" content="cE97ArV7TzqBzkmeRVVhJ8O6GWME2iG_bRvjBTlNb4o." />
+    <meta name="dfp-ad-unit-path" content="us" />
+    <meta name="dfp-amazon-enabled" content="false" />
+    <link rel="alternate" type="application/json+oembed" href="https://www.nytimes.com/svc/oembed/json/?url=https%3A%2F%2Fwww.nytimes.com%2F2016%2F11%2F10%2Fus%2Ftrump-election-protests.html" title="‘Not Our President’: Protests Spread After Donald Trump’s Election" />
+
+    <link id="legacy-zam5nzz" rel="stylesheet" type="text/css" href="https://typeface.nyt.com/css/zam5nzz.css" media="all" />
+    <!--[if (gt IE 9)|!(IE)]> <!-->
+    <link rel="stylesheet" type="text/css" media="screen" href="https://a1.nyt.com/assets/article/20170403-111158/css/article/story/styles.css" />
+    <!--<![endif]-->
+    <!--[if lte IE 9]>
+    <link rel="stylesheet" type="text/css" media="screen" href="https://a1.nyt.com/assets/article/20170403-111158/css/article/story/styles-ie.css" />
+    <![endif]-->
+    <link rel="stylesheet" type="text/css" media="print" href="https://a1.nyt.com/assets/article/20170403-111158/css/article/story/styles-print.css" />
+    <!--  begin abra  -->
+    <script>
+        var NYTD=NYTD||{};NYTD.Abra=function(t){"use strict";function n(t){var n=a[t];return n&&n[1]||null}function e(t,n){if(t){var e,o,r=n[0],a=n[1],u=0,c=0;if(1!==a.length||4294967296!==a[0])for(e=i(t+" "+r)>>>0,u=0,c=0;o=a[u++];)if(e<(c+=o[0]))return o}}function o(n,e,o,i){s+="subject="+n+"&test="+encodeURIComponent(e)+"&variant="+encodeURIComponent(o||0)+"&url="+encodeURIComponent(t.location.href)+"&instant=1&skipAugment=true\n",i&&f.push(i),c||(c=t.setTimeout(r,0))}function r(){var n=new t.XMLHttpRequest,e=f;n.withCredentials=!0,n.open("POST",u),n.onreadystatechange=function(){var t,o;if(4==n.readyState)for(t=200==n.status?null:new Error(n.statusText);o=e.shift();)o(t)},n.send(s),s="",f=[],c=null}function i(t){for(var n,e,o,r,i,a,u,c=0,s=0,f=[],l=[n=1732584193,e=4023233417,~n,~e,3285377520],h=[],p=t.length;s<=p;)h[s>>2]|=(s<p?t.charCodeAt(s):128)<<8*(3-s++%4);for(h[u=p+8>>2|15]=p<<3;c<=u;c+=16){for(n=l,s=0;s<80;n=[0|[(a=((t=n[0])<<5|t>>>27)+n[4]+(f[s]=s<16?~~h[c+s]:a<<1|a>>>31)+1518500249)+((e=n[1])&(o=n[2])|~e&(r=n[3])),i=a+(e^o^r)+341275144,a+(e&o|e&r|o&r)+882459459,i+1535694389][0|s++/20],t,e<<30|e>>>2,o,r])a=f[s-3]^f[s-8]^f[s-14]^f[s-16];for(s=5;s;)l[--s]=l[s]+n[s]|0}return l[0]}var a,u,c,s="",f=[];return n.init=function(n,r){var i,c,s,f,l,h=[],p=(t.document.cookie.match(/(^|;) *nyt-a=([^;]*)/)||[])[2],d=(t.document.cookie.match(/(^|;) *ab7=([^;]*)/)||[])[2],m=new RegExp("[?&]abra(=([^&#]*))"),g=m.exec(t.location.search);if(g&&g[2]&&(d=d?g[2]+"&"+d:g[2]),a)throw new Error("can't init twice");if(u=r,a={},d)for(d=decodeURIComponent(d).split("&"),i=0;i<d.length;i++)l=d[i].split("="),l[0]in a||(a[l[0]]=[,l[1]],l[1]&&h.push(l[0]+"="+l[1]));for(i=0;i<n.length;i++)s=n[i],c=s[0],c in a||(f=e(p,s)||[],a[c]=f,f[1]&&h.push(c.replace(/[^\w-]/g)+"="+(""+f[1]).replace(/[^\w-]/g)),f[2]&&o("ab-alloc",c,f[1]));h.length&&t.document.documentElement.setAttribute("data-nyt-ab",h.join(" "))},n.reportExposure=function(n,e){var r=a[n];r&&r[2]?o("ab-expose",n,r[1],e):e&&t.setTimeout(function(){e(null)},0)},n}(this);
+    </script>
+    <script>NYTD.Abra.init([["www-story-reader-satisfaction",[[21474837,"Control",1],[21474836,"VariantA",1],[4252017623,null,0]]],["www-signup-favor-test",[[2147483648,"0",1],[2147483648,"1",1]]],["www-fixed-nav-subscribe-test",[[4294967296,"1",1]]],["www-ad-diagnostic",[[21474837,"1",0],[4273492459,null,0]]],["www-fabrik-off",[[4294967296,"1",1]]],["www-auto-newsletter",[[4294967296,"1",1]]],["www-follow-test-1",[[4080218932,"control",1],[214748364,"variant",1]]],["www-STORY_3bundlePayflow-v3",[[2147483648,"control",1],[2147483648,"1",1]]],["www-story-1427-ad-aggro",[[42949673,"control",1],[42949673,"10",1],[42949673,"8",1],[42949673,"6",1],[42949673,"4",1],[42949673,"pro-10",1],[42949673,"pro-8",1],[42949673,"pro-6",1],[42949673,"pro-4",1],[3908420239,null,0]]],["EC_SampleTest",[[2147483648,"variantA",0],[2147483648,"variantB",0]]],["EC_DigiAbandonmentTest",[[4294967296,"sendAbandonmentEmail",1]]],["EC_HdAbandonmentTest",[[2147483648,"control",1],[2147483648,"sendAbandonmentEmail",1]]],["EC_CrosswordsUpsellTest",[[2147483648,"control",1],[2147483648,"upsell",1]]],["mapleFreeTrial",[[1073741824,"0",1],[1073741824,"1",1],[1073741824,"2",1],[1073741824,"3",1]]],["EC_NewSubOnboardingTest",[[2147483648,"control",1],[2147483648,"sov1",1]]],["PaywallAU",[[1417339208,"0",1],[1417339208,"1",1],[1460288880,"2",1]]]], '//et.nytimes.com/')</script>
+    <!--  end abra  -->
+    <script id="page-config-data" type="text/json">
+{"pageconfig":{"ledeMediaSize":"large","keywords":["article-medium"],"collections":{"sections":["newyork","us","politics"],"syndicated":["apple","facebook"]}}}</script>
+    <script id="display_overrides">
+        []    </script>
+
+    <!-- Media.net Initialization Script -->
+    <!--NY times Desktop-->
+    <script type="text/javascript">
+        var googletag = googletag || {};
+        googletag.cmd = googletag.cmd || [];
+        (function () {
+            window.advBidxc = window.advBidxc || {};
+            window.advBidxc.renderAd = function () {};
+            window.advBidxc.startTime = new Date().getTime();
+            window.advBidxc.customerId = "8CU2553YN"; //Media.net Customer ID
+            window.advBidxc.timeout = 300;
+            function loadScript(tagSrc) {
+                if (tagSrc.substr(0, 4) !== 'http') {
+                    var isSSL = 'https:' == document.location.protocol;
+                    tagSrc = (isSSL ? 'https:' : '') + tagSrc;
+                }
+                var scriptTag = document.createElement('script'),
+                    placeTag = document.getElementsByTagName("script")[0];
+                scriptTag.type = 'text/javascript';
+                scriptTag.async = true;
+                scriptTag.src = tagSrc;
+                placeTag.parentNode.insertBefore(scriptTag, placeTag);
+            }
+
+            function loadGPT() {
+                if (!window.advBidxc.isAdServerLoaded) {
+                    loadScript('//www.googletagservices.com/tag/js/gpt.js');
+                    window.advBidxc.isAdServerLoaded = true;
+                }
+            }
+
+            window.advBidxc.loadGPT = setTimeout(loadGPT, window.advBidxc.timeout);
+        })();
+    </script>
+    <script src="https://contextual.media.net/bidexchange.js?cid=8CU2553YN&amp;https=1"></script>
+
+    <!-- A9 Initialization Script -->
+    <script type="text/javascript">
+        var amznads = amznads || {};
+        amznads.asyncParams = {
+            'id': '3030',
+            'callbackFn': function() {
+                try {
+                    amznads.setTargetingForGPTAsync('amznslots');
+                } catch (e) { }
+            },
+            'timeout': 1000
+        };
+
+        (function() {
+            var a, s = document.getElementsByTagName("script")[0];
+            a = document.createElement("script");
+            a.type = "text/javascript";
+            a.async = true;
+            a.src = "https://c.amazon-adsystem.com/aax2/amzn_ads.js";
+            s.parentNode.insertBefore(a, s);
+        })();
+    </script>
+    <script type="text/json" id="trending-link-json">
+    </script>
+
+    <!--esi
+    <script id="user-info-data" type="application/json">
+    <esi:include src="/svc/web-products/userinfo-v3.json" />
+    </script>
+    -->
+    <script id="magnum-feature-flags" type="application/json">["limitFabrikSave","moreFollowSuggestions","unfollowComments","scoopTool","videoVHSCover","videoVHSShareTools","videoVHSLive","videoVHSNewControls","videoVHSEmbeddedOnly","allTheEmphases","freeTrial","dedupeWhatsNext","trendingPageLinks","sprinklePaidPost","headerBidder","standardizeWhatsNextCollection","onlyLayoutA","simple","simpleExtendedByline","collectionsWhatsNext","mobileMediaViewer","podcastInLede","MovieTickets","MoreInSubsectionFix","seriesIssueMarginalia","serverSideCollectionUrls","multipleBylines","fabrikWebsocketsOnly","translationLinks","papihttps","verticalFullBleed","updateRestaurantReservations","mapDining","newsletterInlineModule","PersonalizationApiUpdate","a9HeaderEnabled","removeInternationalEdition","headlineBalancer","clientSideABRA","newsletterTitleTracking","surveyInterstitial","removeFBMessengerPromo","removeMarginaliaAbTest","paidpostSprinklingFix","abraOverrideVersion","headlineBalancerEverywhere","signupFavor","lazyloadOakImages","mapleFreeTrial","adQuerySupportForMultipleUserAddedKeywords","removeSectionDependentAdLogicForJanuary","oakUpdateAdStride","autoPlaceNewsletter","piiBlockDFP","adExclusiveIERibbonCheck","FlexAdDoubleHeightTracking","didScroll","supportedByAdFullBleed","anchorsHttps","oakBylineMargin","TopFlexAdSiteWide","BundlePayFlow","loadArticleOptimizely","oakStyleTouchups","oakBasicHeader","story1427AdAggro","story1427AdAggroTracking"]</script>
+    <script>
+        var require = {
+            baseUrl: 'https://a1.nyt.com/assets/',
+            waitSeconds: 20,
+            paths: {
+                'foundation': 'article/20170403-111158/js/foundation',
+                'shared': 'article/20170403-111158/js/shared',
+                'article': 'article/20170403-111158/js/article',
+                'application': 'article/20170403-111158/js/article/story',
+                'videoFactory': 'https://static01.nyt.com/js2/build/video/2.0/videofactoryrequire',
+                'videoPlaylist': 'https://static01.nyt.com/js2/build/video/players/extended/2.0/appRequire',
+                'auth/mtr': 'https://static01.nyt.com/js/mtr',
+                'auth/growl': 'https://static01.nyt.com/js/auth/growl/default',
+                'vhs': 'https://static01.nyt.com/video/vhs/build/vhs-2.x.min'
+            },
+            map: {
+                '*': {
+                    'story/main': 'article/story/main'
+                }
+            }
+        };
+    </script>
+    <!--[if (gte IE 9)|!(IE)]> <!-->
+    <script data-main="foundation/main" src="https://a1.nyt.com/assets/article/20170403-111158/js/foundation/lib/framework.js"></script>
+    <!--<![endif]-->
+    <!--[if lt IE 9]>
+    <script>
+        require.map['*']['foundation/main'] = 'foundation/legacy_main';
+    </script>
+    <script data-main="foundation/legacy_main" src="https://a1.nyt.com/assets/article/20170403-111158/js/foundation/lib/framework.js"></script>
+    <![endif]-->
+    <script>
+        require(['foundation/main'], function () {
+            require(['auth/mtr', 'auth/growl']);
+        });
+    </script>
+</head>
+
+<body>
+
+<style>
+    .lt-ie10 .messenger.suggestions {
+        display: block !important;
+        height: 50px;
+    }
+
+    .lt-ie10 .messenger.suggestions .message-bed {
+        background-color: #f8e9d2;
+        border-bottom: 1px solid #ccc;
+    }
+
+    .lt-ie10 .messenger.suggestions .message-container {
+        padding: 11px 18px 11px 30px;
+    }
+
+    .lt-ie10 .messenger.suggestions .action-link {
+        font-family: "nyt-franklin", arial, helvetica, sans-serif;
+        font-size: 10px;
+        font-weight: bold;
+        color: #a81817;
+        text-transform: uppercase;
+    }
+
+    .lt-ie10 .messenger.suggestions .alert-icon {
+        background: url('https://static01.nyt.com/images/icons/icon-alert-12x12-a81817.png') no-repeat;
+        width: 12px;
+        height: 12px;
+        display: inline-block;
+        margin-top: -2px;
+        float: none;
+    }
+
+    .lt-ie10 .masthead,
+    .lt-ie10 .navigation,
+    .lt-ie10 .comments-panel {
+        margin-top: 50px !important;
+    }
+
+    .lt-ie10 .ribbon {
+        margin-top: 97px !important;
+    }
+</style>
+<div id="suggestions" class="suggestions messenger nocontent robots-nocontent" style="display:none;">
+    <div class="message-bed">
+        <div class="message-container last-message-container">
+            <div class="message">
+                <span class="message-content">
+                    <i class="icon alert-icon"></i><span class="message-title">NYTimes.com no longer supports Internet Explorer 9 or earlier. Please upgrade your browser.</span>
+                    <a href="http://www.nytimes.com/content/help/site/ie9-support.html" class="action-link">LEARN MORE »</a>
+                </span>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div id="shell" class="shell">
+    <header id="masthead" class="masthead masthead-theme-standard" role="banner">
+        <div class="container">
+            <div class="quick-navigation button-group">
+                <button class="button sections-button"><i class="icon sprite-icon"></i><span class="button-text">Sections</span></button>
+                <button class="button home-button" data-href="http://www.nytimes.com/" title="Go to the home page to see the latest top stories."><i class="icon sprite-icon"></i>
+                    <span class="button-text">Home</span>
+                </button>
+                <button class="button search-button"><i class="icon sprite-icon"></i><span class="button-text">Search</span></button>
+                <a class="button skip-button skip-to-content visually-hidden focusable" href="#story-header">Skip to content</a>
+                <a class="button skip-button skip-to-navigation visually-hidden focusable" href="#site-index-navigation">Skip to navigation</a>
+                <a class="button skip-button skip-to-mobile visually-hidden focusable" href="http://mobile.nytimes.com/2016/11/10/us/trump-election-protests.html">View mobile version</a>
+            </div><!-- close button-group -->
+            <div class="branding">
+                <h2 class="branding-heading">
+                    <a id="branding-heading-link" href="http://www.nytimes.com/">
+                        <span class="visually-hidden">The New York Times</span>
+                    </a>
+                </h2>
+                <script>window.magnum.writeLogo('small', 'https://a1.nyt.com/assets/article/20170403-111158/images/foundation/logos/', 'us', 'masthead-theme-standard', 'standard', 'branding-heading-link', 'article');</script>
+            </div><!-- close branding -->
+            <div class="story-meta">
+                <h6 class="kicker"><span class="kicker-label"><a href="https://www.nytimes.com/section/us">U.S.</a></span><span class="pipe">|</span>‘Not Our President’: Protests Spread After Donald Trump’s Election</h6>
+            </div><!-- close story-meta -->
+            <div class="user-tools">
+                <div id="Bar1" class="ad bar1-ad nocontent robots-nocontent"></div>
+                <div id="sharetools-masthead" aria-label="tools" role="group" class="sharetools theme-classic  sharetools-masthead  "
+                     data-shares="facebook,twitter,email,show-all,save"
+                     data-url="https://www.nytimes.com/2016/11/10/us/trump-election-protests.html"
+                     data-title="‘Not Our President’: Protests Spread After Donald Trump’s Election"
+                     data-author="By CHRISTOPHER MELE and ANNIE CORREAL"
+                     data-media="https://static01.nyt.com/images/2016/11/11/us/11attack2_xp/11attack2_xp-jumbo.jpg"
+                     data-description="Demonstrators marched through Manhattan toward Trump Tower, and similar protests took place in other cities and on college campuses across the country."
+                     data-publish-date="November 9, 2016"
+                >
+                    <div class="ad sharetools-inline-article-ad hidden nocontent robots-nocontent">
+                    </div>
+                </div><!-- close shareTools -->
+                <button class="button search-button"><i class="icon sprite-icon"></i><span class="button-text">Search</span></button>
+                <div class="user-tools-button-group button-group">
+                    <button class="button subscribe-button hidden" data-href="http://www.nytimes.com/subscriptions/Multiproduct/lp3004.html?campaignId=4XUYF">Subscribe Now</button>
+                    <button class="button login-button login-modal-trigger hidden">Log In</button>
+                    <button class="button notifications-button hidden"><i class="icon sprite-icon"></i><span class="button-text">0</span></button>
+                    <button class="button user-settings-button"><i class="icon sprite-icon"></i><span class="button-text">Settings</span></button>
+                </div><!-- close user-tools-button-group -->
+            </div><!-- close user-tools -->
+        </div><!-- close container -->
+        <div class="search-flyout-panel flyout-panel">
+            <button class="button close-button" type="button"><i class="icon"></i><span class="visually-hidden">Close search</span></button>
+            <nav class="search-form-control form-control layout-horizontal">
+                <h2 class="visually-hidden">Site Search Navigation</h2>
+                <form class="search-form" role="search">
+                    <div class="control">
+                        <div class="label-container visually-hidden">
+                            <label for="search-input">Search NYTimes.com</label>
+                        </div>
+                        <div class="field-container">
+                            <input id="search-input" name="search-input" type="text" class="search-input text" autocomplete="off" placeholder="Search NYTimes.com" />
+
+                            <button type="button" class="button clear-button" tabindex="-1" aria-describedby="clear-search-input"><i class="icon"></i><span id="clear-search-input" class="visually-hidden">Clear this text input</span></button>
+                            <div class="auto-suggest" style="display: none;">
+                                <ol></ol>
+                            </div>
+                            <button class="button submit-button" type="submit">Go</button>
+                        </div>
+                    </div><!-- close control -->
+                </form>
+            </nav>
+
+
+        </div><!-- close flyout-panel -->
+        <div id="notification-modals" class="notification-modals"></div>
+        <span class="story-short-url"><a href="https://nyti.ms/2elqdJq">https://nyti.ms/2elqdJq</a></span></header>
+    <nav id="ribbon" class="ribbon ribbon-start nocontent robots-nocontent" aria-hidden="true">
+        <div class="nocontent robots-nocontent">
+            <ol class="ribbon-menu">
+                <li class="collection ribbon-loader">
+                    <div class="loader loader-t-logo-32x32-ecedeb-ffffff"><span class="visually-hidden">Loading...</span></div>
+                </li>
+            </ol>
+            <div class="ribbon-navigation-container">
+                <nav class="ribbon-navigation next">
+                    <span class="visually-hidden">See next articles</span>
+                    <div class="arrow arrow-right">
+                        <div class="arrow-conceal"></div>
+                    </div>
+                </nav>
+                <nav class="ribbon-navigation previous">
+                    <span class="visually-hidden">See previous articles</span>
+                    <div class="arrow arrow-left">
+                        <div class="arrow-conceal"></div>
+                    </div>
+                </nav>
+            </div>
+        </div><!-- close nocontent -->
+    </nav>
+
+    <script type="text/javascript">
+        (function () {
+            var ribbon;
+            if (window.magnum.getFlags().indexOf('adAggro') !== -1 &&
+                (window.NYTD.Abra('www-story-pro-agro') !== 'control' &&
+                window.NYTD.Abra('www-story-pro-agro') !== null &&
+                window.NYTD.Abra('www-story-pro-agro') !== 'null' &&
+                window.NYTD.Abra('www-story-pro-agro') !== '')) {
+                ribbon = document.querySelector('#ribbon');
+                if (ribbon && ribbon.parentNode) {
+                    ribbon.parentNode.removeChild(ribbon);
+                }
+            }
+        })();
+    </script>
+    <nav id="navigation" class="navigation">
+        <h2 class="visually-hidden">Site Navigation</h2>
+    </nav><!-- close navigation -->
+
+    <nav id="mobile-navigation" class="mobile-navigation hidden">
+        <h2 class="visually-hidden">Site Mobile Navigation</h2>
+    </nav><!-- close mobile-navigation -->
+
+    <div id="navigation-edge" class="navigation-edge"></div>
+    <div id="page" class="page">
+        <div id="TopAd" class="ad top-ad nocontent robots-nocontent">
+            <div class="accessibility-ad-header visually-hidden">
+                <p>Advertisement</p>
+            </div>
+        </div>
+
+        <main id="main" class="main" role="main">
+            <article id="story" class="story theme-main   ">
+
+                <div id='TragedyAd' class='ad tragedy-ad nocontent robots-nocontent'></div>
+
+
+                <header id="story-header" class="story-header">
+                    <div id="story-meta" class="story-meta ">
+                        <div class="supported-by hidden nocontent robots-nocontent">
+                            <span class="ad-label">Supported by</span>
+                            <div id="supported-by-ad" class="supported-by-ad ad"></div>
+                        </div>
+                        <h3 class="kicker">
+                            <span class="kicker-label"><a href="https://www.nytimes.com/section/us">U.S.</a></span>                                                                                                                                            </h3>
+                        <h1 itemprop="headline" id="headline" class="headline">‘Not Our President’: Protests Spread After Donald Trump’s Election</h1>
+                        <div id="story-meta-footer" class="story-meta-footer">
+
+
+                            <p class="byline-dateline"><span class="byline" itemprop="author creator" itemscope itemtype="http://schema.org/Person"  itemid="https://www.nytimes.com/by/christopher-mele">By <a href="https://www.nytimes.com/by/christopher-mele" title="More Articles by CHRISTOPHER MELE"><span class="byline-author" data-byline-name="CHRISTOPHER MELE" itemprop="name">CHRISTOPHER MELE</span></a> and </span><span class="byline" itemprop="author creator" itemscope itemtype="http://schema.org/Person"  itemid="https://www.nytimes.com/by/annie-correal"><a href="https://www.nytimes.com/by/annie-correal" title="More Articles by ANNIE CORREAL"><span class="byline-author" data-byline-name="ANNIE CORREAL" itemprop="name" data-twitter-handle="anniecorreal">ANNIE CORREAL</span></a></span><time class="dateline" datetime="2017-02-28T08:02:06-05:00" itemprop="dateModified" content="2017-02-28T08:02:06-05:00">NOV. 9, 2016</time>
+                            </p>
+
+                            <div class="story-meta-footer-sharetools">
+                                <div id="sharetools-story-meta-footer" aria-label="tools" role="group" class="sharetools theme-classic  sharetools-story-meta-footer  "
+                                     data-shares="facebook,twitter,email,show-all,save"
+                                     data-url="https://www.nytimes.com/2016/11/10/us/trump-election-protests.html"
+                                     data-title="‘Not Our President’: Protests Spread After Donald Trump’s Election"
+                                     data-author="By CHRISTOPHER MELE and ANNIE CORREAL"
+                                     data-media="https://static01.nyt.com/images/2016/11/11/us/11attack2_xp/11attack2_xp-jumbo.jpg"
+                                     data-description="Demonstrators marched through Manhattan toward Trump Tower, and similar protests took place in other cities and on college campuses across the country."
+                                     data-publish-date="November 9, 2016"
+                                >
+                                    <a class="visually-hidden skip-to-text-link" href="#story-continues-1">Continue reading the main story</a>
+                                    <span class="sharetools-label visually-hidden">Share This Page</span>
+                                    <div class="ad sharetools-inline-article-ad hidden nocontent robots-nocontent">
+                                        <a class="visually-hidden skip-to-text-link" href="#story-continues-1">Continue reading the main story</a>
+                                    </div>
+                                </div><!-- close shareTools -->
+                            </div>
+                        </div><!-- close story-meta-footer -->
+                    </div><!-- close story-meta -->
+                </header>
+
+                <script type="text/javascript">
+                    if (
+                        window.magnum
+                        && window.magnum.getFlags().indexOf('headlineBalancer') > 0
+                        && window.magnum.headlineBalancer
+                        && window.magnum.headlineBalancer.initialize
+                        && window.magnum.headlineBalancer.shouldRun()
+                    ) {
+                        window.magnum.headlineBalancer.initialize();
+                    }
+                </script>
+
+
+                <div class="story-body-supplemental">
+                    <div class="story-body story-body-1">
+                        <figure class="promo media video lede layout-large-horizontal "
+                                data-videoid="100000004759928"
+                                data-media-action="modal"
+                                data-autoplay="false"
+                                data-embedded="false"
+                                data-adsensitivity=""
+                                data-live="false"
+                                aria-label="media" role="group">
+                            <span class="visually-hidden">Video</span>
+
+
+
+                            <figcaption class="caption">
+                                <h4 class="headline">Student Protests Break Out Nationwide</h4>
+
+                                <div class="caption-video">
+                                    <div class="summary-credit">
+                                        <p class="summary">Protests developed at high schools and colleges across the country after the election of Donald J. Trump.</p>
+                                        <span class="credit video-credit" itemprop="copyrightHolder">
+                    By ROBIN LINDSAY and MALACHY BROWNE on                                                                <span class="visually-hidden">Publish Date </span>November 9, 2016.
+                                    </span>
+                                        <span class="credit photo-credit" itemprop="copyrightHolder">
+                    Photo by Jim Wilson/The New York Times.
+                </span>
+                                        <a class="video-link" href= https://www.nytimes.com/video/us/100000004759928/student-protests-break-out-nationwide.html?action=click&amp;contentCollection=us&amp;module=lede&amp;region=caption&amp;pgtype=article >Watch in Times Video &#187;</a>
+                                    </div>
+
+                                    <div class="sharetools-video-container">
+                                        <div id="sharetools-video-tools-100000004759928"
+                                             class="sharetools sharetools-video-tools">
+                                            <ul>
+                                                <li class="sharetool embed-sharetool">
+                                                    <a href="javascript:;" data-share="embed" data-modal-title="">
+                                                        <i class="icon sprite-icon"></i>
+                                                        <span class="sharetool-text ">embed</span>
+                                                    </a>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                        <div id="sharetools-video-inline-100000004759928"
+                                             class="sharetools sharetools-video-inline"
+                                             data-shares="facebook|,twitter|"
+                                             data-url="https://www.nytimes.com/video/us/100000004759928/student-protests-break-out-nationwide.html?action=click&amp;contentCollection=us&amp;module=lede&amp;region=caption&amp;pgtype=article"
+                                             data-title="Student Protests Break Out Nationwide"
+                                             data-description="Protests developed at high schools and colleges across the country after the election of Donald J. Trump."
+                                             data-content-type="video">
+                                        </div>
+                                    </div>
+                                </div>
+                            </figcaption>
+                        </figure>
+                        <p class="story-body-text story-content" data-para-count="185" data-total-count="185">Thousands of people across the country marched, shut down highways, burned effigies and shouted angry slogans on Wednesday night to protest the election of <a href="http://www.nytimes.com/topic/person/donald-trump?inline=nyt-per" title="More articles about Donald J. Trump." class="meta-per">Donald J. Trump</a> as president.</p><p class="story-body-text story-content" data-para-count="157" data-total-count="342">The demonstrations, fueled by social media, continued into the early hours of Thursday. The crowds swelled as the night went on but remained mostly peaceful.</p><p class="story-body-text story-content" data-para-count="216" data-total-count="558">Protests were reported in cities as diverse as Dallas and Oakland and included marches in Boston; Chicago; Portland, Ore.; Seattle and Washington and at college campuses in California, Massachusetts and Pennsylvania.</p><p class="story-body-text story-content" data-para-count="392" data-total-count="950">In Oakland alone, the<a href="http://local.nixle.com/alert/5774587/"> Police Department said</a>, the crowd grew from about 3,000 people at 7 p.m. to 6,000 an hour later. The situation grew tense late Wednesday, <a href="http://www.sfgate.com/bayarea/article/Anti-Trump-protests-in-Oakland-turn-violent-10605621.php">with SFGate.com reporting</a> that a group of protesters had started small fires in the street and broken windows. Police officers in riot gear were called in, and at least one officer was injured, <a href="http://abc7news.com/news/fires-erupts-vandalism-reported-at-anti-trump-protest-in-oakland-/1599421/">according to other local news reports</a>.</p><figure class="media slideshow promo launch-media-viewer embedded layout-large-vertical" id="slideshow-100000004760946" data-media-action="modal" aria-label="media" role="group"
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 itemprop="associatedMedia" itemscope
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 itemid="https://static01.nyt.com/images/2016/11/11/us/11attack2_xp/11attack2_xp-blog427.jpg"
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 itemtype="http://schema.org/ImageObject"
+                    >
+                        <script type="application/json">
+                            {"url":"https:\/\/www.nytimes.com\/https:\/\/static01.nyt.com\/slideshow\/2016\/11\/11\/us\/the-anti-trump-protests-that-erupted-after-the-election.html","headline":"The Anti-Trump Protests That Erupted After the Election","summary":"The day after Donald J. Trump was voted into the White House, thousands marched, shut down highways, burned effigies and shouted angry slogans in protest.","content_kicker":"","section_name":"us","subsection_name":"","publication_date":1478795371,"id":100000004760946,"imageslideshow":{"intro":"","slides":[{"data_id":100000004760912,"slide_url":"11attack2_xp","image_type":"photo","caption":{"full":"<p>A pro-Trump supporter, right, clashed with an anti-Trump protester at Lee Circle in New Orleans on Wednesday after the man on the left grabbed a Trump flag from a truck.<\/p>","short":"A pro-Trump supporter, right, clashed with an anti-Trump protester at Lee Circle in New Orleans."},"credit":"Matthew Hinton\/The Advocate, via Associated Press.","image_crops":{"master768":{"height":887,"width":768,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-master768.jpg"},"videoSixteenByNine495":{"height":278,"width":495,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNine495.jpg"},"thumbWide":{"height":126,"width":190,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-thumbWide.jpg"},"largeHorizontalJumbo":{"height":682,"width":1024,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-largeHorizontalJumbo.jpg"},"articleLarge":{"height":693,"width":600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-articleLarge.jpg"},"hpLarge":{"height":287,"width":511,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-hpLarge.jpg"},"mediumThreeByTwo440":{"height":293,"width":440,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-mediumThreeByTwo440.jpg"},"largeHorizontal375":{"height":250,"width":375,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-largeHorizontal375.jpg"},"thumbLarge":{"height":150,"width":150,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-thumbLarge.jpg"},"mediumFlexible177":{"height":123,"width":177,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-mediumFlexible177.jpg"},"videoSixteenByNine540":{"height":304,"width":540,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNine540.jpg"},"square320":{"height":320,"width":320,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-square320.jpg"},"square640":{"height":640,"width":640,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-square640.jpg"},"moth":{"height":151,"width":151,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-moth.jpg"},"videoSmall":{"height":281,"width":500,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSmall.jpg"},"thumbStandard":{"height":75,"width":75,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-thumbStandard.jpg"},"videoSixteenByNine225":{"height":126,"width":225,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNine225.jpg"},"articleInline":{"height":132,"width":190,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-articleInline.jpg"},"smallSquare252":{"height":252,"width":252,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-smallSquare252.jpg"},"watch308":{"height":348,"width":312,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-watch308.jpg"},"hpSmall":{"height":113,"width":163,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-hpSmall.jpg"},"videoFifteenBySeven2610":{"height":1218,"width":2610,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoFifteenBySeven2610.jpg"},"slide":{"height":500,"width":433,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-slide.jpg"},"videoSixteenByNine96":{"height":54,"width":96,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNine96.jpg"},"master1050":{"height":1213,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-master1050.jpg"},"watch268":{"height":303,"width":272,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-watch268.jpg"},"master495":{"height":572,"width":495,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-master495.jpg"},"largeWidescreen573":{"height":322,"width":573,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-largeWidescreen573.jpg"},"sfSpan":{"height":263,"width":395,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-sfSpan.jpg"},"jumbo":{"height":1024,"width":887,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-jumbo.jpg"},"videoSixteenByNine150":{"height":84,"width":150,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNine150.jpg"},"videoSixteenByNine390":{"height":219,"width":390,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNine390.jpg"},"mediumSquare149":{"height":149,"width":149,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-mediumSquare149.jpg"},"largeWidescreen1050":{"height":590,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-largeWidescreen1050.jpg"},"videoSixteenByNine310":{"height":174,"width":310,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNine310.jpg"},"videoSixteenByNine1050":{"height":591,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNine1050.jpg"},"master180":{"height":208,"width":180,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-master180.jpg"},"smallSquare168":{"height":168,"width":168,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-smallSquare168.jpg"},"mediumThreeByTwo225":{"height":150,"width":225,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-mediumThreeByTwo225.jpg"},"verticalTwoByThree735":{"height":1102,"width":735,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-verticalTwoByThree735.jpg"},"facebookJumbo":{"height":549,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-facebookJumbo.jpg"},"filmstrip":{"height":190,"width":190,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-filmstrip.jpg"},"master315":{"height":364,"width":315,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-master315.jpg"},"miniMoth":{"height":70,"width":151,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-miniMoth.jpg"},"videoSixteenByNine480":{"height":270,"width":480,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNine480.jpg"},"master675":{"height":780,"width":675,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-master675.jpg"},"tmagArticle":{"height":684,"width":592,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-tmagArticle.jpg"},"videoSixteenByNine768":{"height":432,"width":768,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNine768.jpg"},"videoThumb":{"height":50,"width":75,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoThumb.jpg"},"videoSixteenByNine600":{"height":338,"width":600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNine600.jpg"},"videoSixteenByNine3000":{"height":1687,"width":3000,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNine3000.jpg"},"tmagSF":{"height":418,"width":362,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-tmagSF.jpg"},"videoSixteenByNineJumbo1600":{"height":900,"width":1600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNineJumbo1600.jpg"},"popup":{"height":500,"width":433,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-popup.jpg"},"mediumThreeByTwo252":{"height":168,"width":252,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-mediumThreeByTwo252.jpg"},"mediumThreeByTwo210":{"height":140,"width":210,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-mediumThreeByTwo210.jpg"},"windowsTile336H":{"height":336,"width":694,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-windowsTile336H.jpg"},"mediumThreeByTwo378":{"height":252,"width":378,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-mediumThreeByTwo378.jpg"},"videoFifteenBySeven1305":{"height":609,"width":1305,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoFifteenBySeven1305.jpg"},"superJumbo":{"height":2048,"width":1773,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-superJumbo.jpg"},"videoLarge":{"height":507,"width":768,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoLarge.jpg"}},"url":null,"short_url":null,"approved_for_syndication":true},{"data_id":100000004760917,"slide_url":"11attack3_xp","image_type":"photo","caption":{"full":"<p>Elizabeth Bushnell, who said she is Muslim, is embraced by Conner Crenshaw, left, and Jamal Edwards during an anti-Trump protest at Lee Circle in New Orleans on Wednesday.<\/p>","short":"Elizabeth Bushnell, who said she is Muslim, is embraced during an protest in New Orleans."},"credit":"Matthew Hinton\/The Advocate, via Associated Press.","image_crops":{"master768":{"height":418,"width":768,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-master768.jpg"},"videoSixteenByNine495":{"height":278,"width":495,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNine495.jpg"},"thumbWide":{"height":126,"width":190,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-thumbWide.jpg"},"largeHorizontalJumbo":{"height":682,"width":1024,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-largeHorizontalJumbo.jpg"},"articleLarge":{"height":327,"width":600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-articleLarge.jpg"},"hpLarge":{"height":287,"width":511,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-hpLarge.jpg"},"mediumThreeByTwo440":{"height":293,"width":440,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-mediumThreeByTwo440.jpg"},"largeHorizontal375":{"height":250,"width":375,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-largeHorizontal375.jpg"},"thumbLarge":{"height":150,"width":150,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-thumbLarge.jpg"},"mediumFlexible177":{"height":125,"width":177,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-mediumFlexible177.jpg"},"videoSixteenByNine540":{"height":304,"width":540,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNine540.jpg"},"square320":{"height":320,"width":320,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-square320.jpg"},"square640":{"height":640,"width":640,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-square640.jpg"},"moth":{"height":151,"width":151,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-moth.jpg"},"videoSmall":{"height":281,"width":500,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSmall.jpg"},"thumbStandard":{"height":75,"width":75,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-thumbStandard.jpg"},"videoSixteenByNine225":{"height":126,"width":225,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNine225.jpg"},"articleInline":{"height":135,"width":190,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-articleInline.jpg"},"smallSquare252":{"height":252,"width":252,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-smallSquare252.jpg"},"watch308":{"height":348,"width":312,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-watch308.jpg"},"hpSmall":{"height":115,"width":163,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-hpSmall.jpg"},"videoFifteenBySeven2610":{"height":1218,"width":2610,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoFifteenBySeven2610.jpg"},"slide":{"height":327,"width":600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-slide.jpg"},"videoSixteenByNine96":{"height":54,"width":96,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNine96.jpg"},"master1050":{"height":571,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-master1050.jpg"},"watch268":{"height":303,"width":272,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-watch268.jpg"},"master495":{"height":269,"width":495,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-master495.jpg"},"largeWidescreen573":{"height":322,"width":573,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-largeWidescreen573.jpg"},"sfSpan":{"height":263,"width":395,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-sfSpan.jpg"},"jumbo":{"height":557,"width":1024,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-jumbo.jpg"},"videoSixteenByNine150":{"height":84,"width":150,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNine150.jpg"},"videoSixteenByNine390":{"height":219,"width":390,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNine390.jpg"},"mediumSquare149":{"height":149,"width":149,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-mediumSquare149.jpg"},"largeWidescreen1050":{"height":590,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-largeWidescreen1050.jpg"},"videoSixteenByNine310":{"height":174,"width":310,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNine310.jpg"},"videoSixteenByNine1050":{"height":591,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNine1050.jpg"},"master180":{"height":98,"width":180,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-master180.jpg"},"smallSquare168":{"height":168,"width":168,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-smallSquare168.jpg"},"mediumThreeByTwo225":{"height":150,"width":225,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-mediumThreeByTwo225.jpg"},"verticalTwoByThree735":{"height":1102,"width":735,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-verticalTwoByThree735.jpg"},"facebookJumbo":{"height":549,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-facebookJumbo.jpg"},"filmstrip":{"height":190,"width":190,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-filmstrip.jpg"},"master315":{"height":171,"width":315,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-master315.jpg"},"miniMoth":{"height":70,"width":151,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-miniMoth.jpg"},"videoSixteenByNine480":{"height":270,"width":480,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNine480.jpg"},"master675":{"height":367,"width":675,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-master675.jpg"},"tmagArticle":{"height":322,"width":592,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-tmagArticle.jpg"},"videoSixteenByNine768":{"height":432,"width":768,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNine768.jpg"},"videoThumb":{"height":50,"width":75,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoThumb.jpg"},"videoSixteenByNine600":{"height":338,"width":600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNine600.jpg"},"videoSixteenByNine3000":{"height":1686,"width":3000,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNine3000.jpg"},"tmagSF":{"height":197,"width":362,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-tmagSF.jpg"},"videoSixteenByNineJumbo1600":{"height":899,"width":1600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNineJumbo1600.jpg"},"popup":{"height":354,"width":650,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-popup.jpg"},"mediumThreeByTwo252":{"height":168,"width":252,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-mediumThreeByTwo252.jpg"},"mediumThreeByTwo210":{"height":140,"width":210,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-mediumThreeByTwo210.jpg"},"windowsTile336H":{"height":336,"width":694,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-windowsTile336H.jpg"},"mediumThreeByTwo378":{"height":252,"width":378,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-mediumThreeByTwo378.jpg"},"videoFifteenBySeven1305":{"height":609,"width":1305,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoFifteenBySeven1305.jpg"},"superJumbo":{"height":1115,"width":2048,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-superJumbo.jpg"},"videoLarge":{"height":507,"width":768,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoLarge.jpg"}},"url":null,"short_url":null,"approved_for_syndication":true},{"data_id":100000004760794,"slide_url":"11protests_xp","image_type":"photo","caption":{"full":"<p>The police clashed with demonstrators blocking traffic on the 101 Freeway through downtown Los Angeles on Wednesday.<\/p>","short":"The police clashed with demonstrators blocking traffic on the 101 Freeway through Los Angeles."},"credit":"Ringo Chiu\/Agence France-Presse \u2014 Getty Images","image_crops":{"master768":{"height":526,"width":768,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-master768.jpg"},"videoSixteenByNine495":{"height":278,"width":495,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNine495.jpg"},"thumbWide":{"height":126,"width":190,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-thumbWide.jpg"},"largeHorizontalJumbo":{"height":683,"width":1024,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-largeHorizontalJumbo.jpg"},"articleLarge":{"height":411,"width":600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-articleLarge.jpg"},"hpLarge":{"height":287,"width":511,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-hpLarge.jpg"},"mediumThreeByTwo440":{"height":293,"width":440,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-mediumThreeByTwo440.jpg"},"largeHorizontal375":{"height":250,"width":375,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-largeHorizontal375.jpg"},"thumbLarge":{"height":150,"width":150,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-thumbLarge.jpg"},"mediumFlexible177":{"height":129,"width":177,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-mediumFlexible177.jpg"},"videoSixteenByNine540":{"height":304,"width":540,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNine540.jpg"},"square320":{"height":320,"width":320,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-square320.jpg"},"square640":{"height":640,"width":640,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-square640.jpg"},"moth":{"height":151,"width":151,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-moth.jpg"},"videoSmall":{"height":281,"width":500,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSmall.jpg"},"thumbStandard":{"height":75,"width":75,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-thumbStandard.jpg"},"videoSixteenByNine225":{"height":126,"width":225,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNine225.jpg"},"articleInline":{"height":138,"width":190,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-articleInline.jpg"},"smallSquare252":{"height":252,"width":252,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-smallSquare252.jpg"},"watch308":{"height":348,"width":312,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-watch308.jpg"},"hpSmall":{"height":118,"width":163,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-hpSmall.jpg"},"videoFifteenBySeven2610":{"height":1218,"width":2610,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoFifteenBySeven2610.jpg"},"slide":{"height":411,"width":600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-slide.jpg"},"videoSixteenByNine96":{"height":54,"width":96,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNine96.jpg"},"master1050":{"height":719,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-master1050.jpg"},"watch268":{"height":303,"width":272,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-watch268.jpg"},"master495":{"height":339,"width":495,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-master495.jpg"},"largeWidescreen573":{"height":322,"width":573,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-largeWidescreen573.jpg"},"sfSpan":{"height":263,"width":395,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-sfSpan.jpg"},"jumbo":{"height":701,"width":1024,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-jumbo.jpg"},"videoSixteenByNine150":{"height":84,"width":150,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNine150.jpg"},"videoSixteenByNine390":{"height":219,"width":390,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNine390.jpg"},"mediumSquare149":{"height":149,"width":149,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-mediumSquare149.jpg"},"largeWidescreen1050":{"height":591,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-largeWidescreen1050.jpg"},"videoSixteenByNine310":{"height":174,"width":310,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNine310.jpg"},"videoSixteenByNine1050":{"height":591,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNine1050.jpg"},"master180":{"height":123,"width":180,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-master180.jpg"},"smallSquare168":{"height":168,"width":168,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-smallSquare168.jpg"},"mediumThreeByTwo225":{"height":150,"width":225,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-mediumThreeByTwo225.jpg"},"verticalTwoByThree735":{"height":1103,"width":735,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-verticalTwoByThree735.jpg"},"facebookJumbo":{"height":550,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-facebookJumbo.jpg"},"filmstrip":{"height":190,"width":190,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-filmstrip.jpg"},"master315":{"height":216,"width":315,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-master315.jpg"},"miniMoth":{"height":70,"width":151,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-miniMoth.jpg"},"videoSixteenByNine480":{"height":270,"width":480,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNine480.jpg"},"master675":{"height":462,"width":675,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-master675.jpg"},"tmagArticle":{"height":405,"width":592,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-tmagArticle.jpg"},"videoSixteenByNine768":{"height":432,"width":768,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNine768.jpg"},"videoThumb":{"height":50,"width":75,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoThumb.jpg"},"videoSixteenByNine600":{"height":338,"width":600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNine600.jpg"},"videoSixteenByNine3000":{"height":1688,"width":3000,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNine3000.jpg"},"tmagSF":{"height":248,"width":362,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-tmagSF.jpg"},"videoSixteenByNineJumbo1600":{"height":900,"width":1600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNineJumbo1600.jpg"},"popup":{"height":445,"width":650,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-popup.jpg"},"mediumThreeByTwo252":{"height":168,"width":252,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-mediumThreeByTwo252.jpg"},"mediumThreeByTwo210":{"height":140,"width":210,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-mediumThreeByTwo210.jpg"},"windowsTile336H":{"height":336,"width":694,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-windowsTile336H.jpg"},"mediumThreeByTwo378":{"height":252,"width":378,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-mediumThreeByTwo378.jpg"},"videoFifteenBySeven1305":{"height":609,"width":1305,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoFifteenBySeven1305.jpg"},"superJumbo":{"height":1403,"width":2048,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-superJumbo.jpg"},"videoLarge":{"height":507,"width":768,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoLarge.jpg"}},"url":null,"short_url":null,"approved_for_syndication":true},{"data_id":100000004760926,"slide_url":"elex-protests","image_type":"photo","caption":{"full":"<p>An anti-Trump protest at Columbus Circle in Manhattan on Wednesday.<\/p>","short":"An anti-Trump protest at Columbus Circle in Manhattan on Wednesday."},"credit":"Hiroko Masuike\/The New York Times","image_crops":{"videoSixteenByNine495":{"height":278,"width":495,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNine495.jpg"},"master768":{"height":512,"width":768,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-master768.jpg"},"thumbWide":{"height":126,"width":190,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-thumbWide.jpg"},"largeHorizontalJumbo":{"height":683,"width":1024,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-largeHorizontalJumbo.jpg"},"articleLarge":{"height":400,"width":600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-articleLarge.jpg"},"hpLarge":{"height":287,"width":511,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-hpLarge.jpg"},"mediumThreeByTwo440":{"height":293,"width":440,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-mediumThreeByTwo440.jpg"},"largeHorizontal375":{"height":250,"width":375,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-largeHorizontal375.jpg"},"thumbLarge":{"height":150,"width":150,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-thumbLarge.jpg"},"mediumFlexible177":{"height":118,"width":177,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-mediumFlexible177.jpg"},"videoSixteenByNine540":{"height":304,"width":540,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNine540.jpg"},"square320":{"height":320,"width":320,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-square320.jpg"},"square640":{"height":640,"width":640,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-square640.jpg"},"moth":{"height":151,"width":151,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-moth.jpg"},"videoSmall":{"height":281,"width":500,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSmall.jpg"},"thumbStandard":{"height":75,"width":75,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-thumbStandard.jpg"},"videoSixteenByNine225":{"height":126,"width":225,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNine225.jpg"},"articleInline":{"height":127,"width":190,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-articleInline.jpg"},"smallSquare252":{"height":252,"width":252,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-smallSquare252.jpg"},"watch308":{"height":348,"width":312,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-watch308.jpg"},"hpSmall":{"height":109,"width":163,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-hpSmall.jpg"},"videoFifteenBySeven2610":{"height":1218,"width":2610,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoFifteenBySeven2610.jpg"},"slide":{"height":400,"width":600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-slide.jpg"},"videoSixteenByNine96":{"height":54,"width":96,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNine96.jpg"},"master1050":{"height":700,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-master1050.jpg"},"watch268":{"height":303,"width":272,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-watch268.jpg"},"master495":{"height":330,"width":495,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-master495.jpg"},"largeWidescreen573":{"height":322,"width":573,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-largeWidescreen573.jpg"},"sfSpan":{"height":263,"width":395,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-sfSpan.jpg"},"jumbo":{"height":683,"width":1024,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-jumbo.jpg"},"videoSixteenByNine150":{"height":84,"width":150,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNine150.jpg"},"videoSixteenByNine390":{"height":219,"width":390,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNine390.jpg"},"mediumSquare149":{"height":149,"width":149,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-mediumSquare149.jpg"},"largeWidescreen1050":{"height":591,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-largeWidescreen1050.jpg"},"videoSixteenByNine310":{"height":174,"width":310,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNine310.jpg"},"videoSixteenByNine1050":{"height":591,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNine1050.jpg"},"master180":{"height":120,"width":180,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-master180.jpg"},"smallSquare168":{"height":168,"width":168,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-smallSquare168.jpg"},"mediumThreeByTwo225":{"height":150,"width":225,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-mediumThreeByTwo225.jpg"},"verticalTwoByThree735":{"height":1103,"width":735,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-verticalTwoByThree735.jpg"},"facebookJumbo":{"height":550,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-facebookJumbo.jpg"},"filmstrip":{"height":190,"width":190,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-filmstrip.jpg"},"miniMoth":{"height":70,"width":151,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-miniMoth.jpg"},"master315":{"height":210,"width":315,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-master315.jpg"},"videoSixteenByNine480":{"height":270,"width":480,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNine480.jpg"},"master675":{"height":450,"width":675,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-master675.jpg"},"tmagArticle":{"height":395,"width":592,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-tmagArticle.jpg"},"videoSixteenByNine768":{"height":432,"width":768,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNine768.jpg"},"videoThumb":{"height":50,"width":75,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoThumb.jpg"},"videoSixteenByNine600":{"height":338,"width":600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNine600.jpg"},"videoSixteenByNine3000":{"height":1688,"width":3000,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNine3000.jpg"},"tmagSF":{"height":241,"width":362,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-tmagSF.jpg"},"videoSixteenByNineJumbo1600":{"height":900,"width":1600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNineJumbo1600.jpg"},"popup":{"height":433,"width":650,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-popup.jpg"},"mediumThreeByTwo252":{"height":168,"width":252,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-mediumThreeByTwo252.jpg"},"mediumThreeByTwo210":{"height":140,"width":210,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-mediumThreeByTwo210.jpg"},"windowsTile336H":{"height":336,"width":694,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-windowsTile336H.jpg"},"mediumThreeByTwo378":{"height":252,"width":378,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-mediumThreeByTwo378.jpg"},"videoFifteenBySeven1305":{"height":609,"width":1305,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoFifteenBySeven1305.jpg"},"superJumbo":{"height":1365,"width":2048,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-superJumbo.jpg"},"videoLarge":{"height":507,"width":768,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoLarge.jpg"}},"url":null,"short_url":null,"approved_for_syndication":true}]},"related_assets":[]}    </script>
+                        <span class="visually-hidden">Slide Show</span>
+                        <div class="image">
+                            <img src="https://static01.nyt.com/images/2016/11/11/us/11attack2_xp/11attack2_xp-blog427.jpg" itemprop="url" itemid="https://static01.nyt.com/images/2016/11/11/us/11attack2_xp/11attack2_xp-blog427.jpg"/>
+
+                            <div class="media-action-overlay">
+                                <i class="icon sprite-icon"></i>
+                                <div class="media-meta">
+                                    <h5 class="kicker"><span class="kicker-label">Slide Show</span><span class="pipe">|</span><span class="counter">4 Photos</span></h5>
+                                    <h4 class="headline">The Anti-Trump Protests That Erupted After the Election</h4>
+                                </div>
+                            </div><!-- close media-action-overlay -->
+
+                        </div><!-- close image -->
+
+                        <figcaption class="caption" itemprop="description">
+                            <h4 class="headline">The Anti-Trump Protests That Erupted After the Election</h4>
+                            <p class="credit" itemprop="copyrightHolder">
+                                <span class="visually-hidden">Credit</span>Matthew Hinton/The Advocate, via Associated Press.        </p>
+                        </figcaption>
+
+                        <meta itemprop="identifier" content="https://static01.nyt.com/images/2016/11/11/us/11attack2_xp/11attack2_xp-blog427.jpg" />
+                        <meta itemprop="height" content="493" />
+                        <meta itemprop="width" content="427" />
+
+                    </figure>
+                        <p class="story-body-text story-content" data-para-count="191" data-total-count="1141">It was the <a href="http://www.nytimes.com/2016/11/10/us/trump-election-protest-berkeley-oakland.html">second night of protests</a> there, following unruly demonstrations that led to <a href="http://abc7news.com/news/thousands-take-to-streets-of-oakland-in-protest-of-election-results/1599421/">property damage and left at least one </a>person injured shortly after Mr. Trump’s election was announced.</p>        <a class="visually-hidden skip-to-text-link" href="#story-continues-1">Continue reading the main story</a>
+                    </div><!-- close story-body -->
+                    <div class="supplemental first" id="supplemental-1">
+                    </div><!-- close supplemental -->
+                </div><!-- close story-body-supplemental -->
+                <div class="story-interrupter" id="story-continues-1">
+                    <div id="FlexAd" class="ad flex-ad nocontent robots-nocontent">
+                        <div class="accessibility-ad-header visually-hidden">
+                            <p>Advertisement</p>
+                        </div>
+                        <a class="visually-hidden skip-to-text-link" href="#story-continues-2">Continue reading the main story</a>
+                        <div class="flex-ad-creative"></div>
+                    </div>
+                </div>
+                <div class="story-body-supplemental">
+                    <div class="story-body story-body-2">
+                        <p class="story-body-text story-content" data-para-count="149" data-total-count="1290" id="story-continues-2">The protests on Wednesday came just hours after Hillary Clinton, in <a href="http://www.nytimes.com/2016/11/09/us/politics/donald-trump-won-now-what.html">her concession speech</a>, asked supporters to give Mr. Trump a “chance to lead.”</p><div id="story-ad-1" class="story-ad ad ad-placeholder nocontent robots-nocontent ">
+                        <div class="accessibility-ad-header visually-hidden">
+                            <p>Advertisement</p>
+                        </div>
+                        <a class="visually-hidden skip-to-text-link" href="#story-continues-3">Continue reading the main story</a>
+                    </div>
+                        <p class="story-body-text story-content" data-para-count="264" data-total-count="1554" id="story-continues-3">One of the <a href="http://www.latimes.com/local/lanow/la-me-ln-downtown-la-trump-protests-20161109-htmlstory.html">biggest demonstrations was in Los Angeles</a>, where protesters burned a Trump effigy at City Hall and shut down a section of Highway 101. Law enforcement officials were called out to disperse the hundreds of people who swarmed across the multilane freeway.</p><p class="story-body-text story-content" data-para-count="131" data-total-count="1685">In New York, crowds converged at Trump Tower, on Fifth Avenue at 56th Street in Midtown Manhattan, where the president-elect lives.</p><div id="story-ad--aggro-4" class="story-ad ad ad-placeholder nocontent robots-nocontent  ad-aggro-4 aggro-only">
+                        <div class="accessibility-ad-header visually-hidden">
+                            <p>Advertisement</p>
+                        </div>
+                        <a class="visually-hidden skip-to-text-link" href="#story-continues-4">Continue reading the main story</a>
+                    </div>
+                        <p class="story-body-text story-content" data-para-count="227" data-total-count="1912" id="story-continues-4">They chanted “Not our president” and “New York hates Trump” and carried signs that said, among other things, “Dump Trump.” Restaurant workers in their uniforms briefly left their posts to cheer on the demonstrators.</p><p class="story-body-text story-content" data-para-count="204" data-total-count="2116">The demonstrations forced streets to be closed, snarled traffic and drew a large police presence. They started in separate waves from Union Square and Columbus Circle and snaked their way through Midtown.</p><div id="story-ad--aggro-6" class="story-ad ad ad-placeholder nocontent robots-nocontent  ad-aggro-6 aggro-only">
+                        <div class="accessibility-ad-header visually-hidden">
+                            <p>Advertisement</p>
+                        </div>
+                        <a class="visually-hidden skip-to-text-link" href="#story-continues-5">Continue reading the main story</a>
+                    </div>
+                        <p class="story-body-text story-content" data-para-count="97" data-total-count="2213" id="story-continues-5">Loaded dump trucks lined Fifth Avenue for two blocks outside Trump Tower as a form of protection.</p><p class="story-body-text story-content" data-para-count="145" data-total-count="2358">Emanuel Perez, 25, of the Bronx, who works at a restaurant in Manhattan and grew up in Guerrero, Mexico, was among the many Latinos in the crowd.</p><p class="story-body-text story-content" data-para-count="328" data-total-count="2686">“I came here because people came out to protest the racism that he’s promoting,” he said in Spanish, referring to Mr. Trump. “I’m not scared for myself personally. What I’m worried about is how many children are going to be separated from their families. It will not be just one. It will be thousands of families.”</p><div id="story-ad--aggro-8" class="story-ad ad ad-placeholder nocontent robots-nocontent  ad-aggro-4 ad-aggro-8 aggro-only">
+                        <div class="accessibility-ad-header visually-hidden">
+                            <p>Advertisement</p>
+                        </div>
+                        <a class="visually-hidden skip-to-text-link" href="#story-continues-6">Continue reading the main story</a>
+                    </div>
+                        <p class="story-body-text story-content" data-para-count="102" data-total-count="2788" id="story-continues-6">Protesters with umbrellas beat a piñata of Mr. Trump, which quickly lost a leg, outside the building.</p><div class="newsletter-signup hidden auto-newsletter" id="newsletter-promo" data-newsletter-productCode="" data-newsletter-productTitle="">
+                        <script type="application/json" id="auto-newsletter-rules">[{"headline":"California Today","summary":"The news and stories that matter to Californians (and anyone else interested in the state), delivered weekday mornings.","product-code":"CA","product-title":"California Today","sample-url":"http:\/\/www.nytimes.com\/newsletters\/sample\/california-today?pgtype=subscriptionspage&version=new&contentId=CA&eventName=sample&module=newsletter-sign-up"},{"headline":"Race\/Related Newsletter","summary":"Join a deep and provocative exploration of race with New York Times journalists.","product-code":"RR","product-title":"Race Related","sample-url":"http:\/\/www.nytimes.com\/newsletters\/sample\/race-related?pgtype=subscriptionspage&version=new&contentId=RR&eventName=sample&module=newsletter-sign-up"},{"headline":"The Interpreter Newsletter","summary":"Understand the world with sharp insight and commentary on the major news stories of the week.","product-code":"INT","product-title":"The Interpreter"}]</script>
+                        <h2 class="headline"></h2>    <p class="summary"></p>    <form name="regilite" class="newsletter-form" method="post" autocomplete="off">
+                        <div class="control input-control">
+                            <div class="form-errors">
+                                <p class="error captcha-error hidden">Please verify you're not a robot by clicking the box.</p>
+                                <p class="error invalid-email-error hidden">Invalid email address. Please re-enter.</p>
+                                <p class="error buffet-error hidden">You must select a newsletter to subscribe to.</p>
+                            </div>
+                            <div class="field-container">
+                                <input id="email" name="email" class="email-input" type="email" aria-required="true" placeholder="Enter your email address" value="">
+                                <button id="submit-button" type="submit" class="button submit-button">Sign Up</button>
+                            </div>
+                        </div><!-- close control -->
+                        <div class="control checkbox-control">
+                            <div class="field-container">
+                                <input id="special-offers" class="checkbox" type="checkbox" name="special-offers" value="MM" checked="">
+                            </div>
+                            <div class="label-container">
+                                <label class="checkboxLabel" for="special-offers">Receive occasional updates and special offers for The New York Times's products and services.</label>
+                            </div>
+                        </div><!-- close control -->
+                        <div class="g-recaptcha" id="captcha-container" data-sitekey="6LeN0R4TAAAAACwPa5WX2QYE0npOf2-2veTOm2Tp"></div>
+                    </form>
+                        <div class="messages">
+                            <h2 class="success-message hidden">Thank you for subscribing.</h2>
+                            <h2 class="error submit-error hidden">An error has occurred. Please try again later.</h2>
+                            <h2 class="subscriber hidden">You are already subscribed to this email.</h2>
+                            <p class="view-all-link hidden"><a href="/newsletters" target="_blank">View all New York Times newsletters.</a></p>
+                        </div><!-- close messages -->
+                        <ul class="footer">
+                            <li id="sample-newsletter-link" class="sample"><a href="" target="_blank">See Sample</a></li>
+                            <li class="manage-email"><a href="/mem/email.html" target="_blank">Manage Email Preferences</a></li>
+                            <li class="logout hidden"><a href="/logout" target="_blank">Not you?</a></li>
+                            <li class="privacy"><a href="/privacy" target="_blank">Privacy Policy</a></li>
+                        </ul><!-- close footer -->
+                        <script src="https://www.google.com/recaptcha/api.js" async="async" defer="defer"></script>
+                    </div>
+                        <p class="story-body-text story-content" data-para-count="83" data-total-count="2871">The Police Department said on Wednesday night that 15 protesters had been arrested.</p><p class="story-body-text story-content" data-para-count="119" data-total-count="2990">Bianca Rivera, 25, of East Harlem, described Mr. Trump’s election as something that was “not supposed to happen.”</p><p class="story-body-text story-content" data-para-count="155" data-total-count="3145">“We’re living in a country that’s supposed to be united, a melting pot,” she said. “It’s exposing all these underground racists and sexists.”</p><div id="story-ad-2" class="story-ad ad ad-placeholder nocontent robots-nocontent  ad-aggro-10">
+                        <div class="accessibility-ad-header visually-hidden">
+                            <p>Advertisement</p>
+                        </div>
+                        <a class="visually-hidden skip-to-text-link" href="#story-continues-7">Continue reading the main story</a>
+                    </div>
+                        <p class="story-body-text story-content" data-para-count="151" data-total-count="3296" id="story-continues-7">Elsewhere in the country, college students gathered in spontaneous marches and asked university leaders to schedule meetings to reflect on the results.</p><p class="story-body-text story-content" data-para-count="175" data-total-count="3471">After <a href="http://www.nytimes.com/2016/11/10/us/politics/trump-speech-transcript.html">Mr. Trump’s victory speech</a>, more than 2,000 students at the University of California, Los Angeles, marched through the streets of the campus’s Westwood neighborhood.</p><div id="story-ad--aggro-12" class="story-ad ad ad-placeholder nocontent robots-nocontent  ad-aggro-4 ad-aggro-6 aggro-only">
+                        <div class="accessibility-ad-header visually-hidden">
+                            <p>Advertisement</p>
+                        </div>
+                        <a class="visually-hidden skip-to-text-link" href="#story-continues-8">Continue reading the main story</a>
+                    </div>
+                        <p class="story-body-text story-content" data-para-count="234" data-total-count="3705" id="story-continues-8">There were similar protests at the University of Southern California, in Los Angeles; University of California campuses in Berkeley, San Diego and Santa Barbara; Temple University, in Philadelphia; and the University of Massachusetts.</p><figure class="media twitter embedded layout-horizontal-inset">
+                        <blockquote class="twitter-tweet">
+                            <p itemprop="articleBody">
+                                Large crowd of anti-Trump protesters outside of Trump Tower in NYC! <a href="https://twitter.com/hashtag/AntiFa?src=hash">#AntiFa</a> <a href="https://t.co/jwQau88DiW">pic.twitter.com/jwQau88DiW</a>        </p> —
+                            Ash J (@AshAgony)
+                            <a href="https://twitter.com/AshAgony/status/796517436002549760">Nov. 10, 2016</a>
+                        </blockquote>
+                        <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+                    </figure>
+                        <p class="story-body-text story-content" data-para-count="77" data-total-count="3782">High school students also walked out of classes in protest in several cities.</p><p class="story-body-text story-content" data-para-count="152" data-total-count="3934">As U.C.L.A. students made their way to classes on Wednesday, they talked about how to make sense of an outcome that had seemed impossible a day earlier.</p><p class="story-body-text story-content" data-para-count="252" data-total-count="4186">“I’m more than a little nervous about the future,” said Blanca Torres, a sophomore anthropology major. “We all want to have conversations with each other, to figure out how to move forward. There’s a whole new reality out there for us now.”</p><p class="story-body-text story-content" data-para-count="99" data-total-count="4285">Chuy Fernandez, a fifth-year economics student, said he was eager to air his unease with his peers.</p><p class="story-body-text story-content" data-para-count="173" data-total-count="4458">“I’m feeling sad with this huge sense of uncertainty,” Mr. Fernandez said. The son of a Mexican immigrant, he said it was difficult not to take the outcome personally.</p><figure class="media twitter embedded layout-horizontal-inset">
+                        <blockquote class="twitter-tweet">
+                            <p itemprop="articleBody">
+                                Flag burning on 5th Avenue in front of Trump Tower right now. <a href="https://t.co/1LAGHCNjxL">pic.twitter.com/1LAGHCNjxL</a>        </p> —
+                            Patrick deHahn (@patrickdehahn)
+                            <a href="https://twitter.com/patrickdehahn/status/796521221680746496">Nov. 10, 2016</a>
+                        </blockquote>
+                        <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+                    </figure>
+                        <div id="story-ad--aggro-16" class="story-ad ad ad-placeholder nocontent robots-nocontent  ad-aggro-4 ad-aggro-8 aggro-only">
+                            <div class="accessibility-ad-header visually-hidden">
+                                <p>Advertisement</p>
+                            </div>
+                            <a class="visually-hidden skip-to-text-link" href="#story-continues-9">Continue reading the main story</a>
+                        </div>
+                        <p class="story-body-text story-content" data-para-count="202" data-total-count="4660" id="story-continues-9">“We’re all just kind of waiting for a ticking time bomb, like looking around and thinking who will be deported,” he said. “That’s the exact opposite of what most of us thought would happen.”</p><p class="story-body-text story-content" data-para-count="138" data-total-count="4798">On Facebook, a page titled “Not My President” <a href="https://www.facebook.com/events/1143506425717593/">called for protesters</a> to gather on Inauguration Day, Jan. 20, in the nation’s capital.</p><p class="story-body-text story-content" data-para-count="175" data-total-count="4973">“We refuse to recognize Donald Trump as the president of the United States, and refuse to take orders from a government that puts bigots into power,” the organizers wrote.</p><div id="story-ad-3" class="story-ad ad ad-placeholder nocontent robots-nocontent  ad-aggro-6">
+                        <div class="accessibility-ad-header visually-hidden">
+                            <p>Advertisement</p>
+                        </div>
+                        <a class="visually-hidden skip-to-text-link" href="#story-continues-10">Continue reading the main story</a>
+                    </div>
+                        <p class="story-body-text story-content" data-para-count="133" data-total-count="5106" id="story-continues-10">“We have to make it clear to the public that we did not choose this man for office and that we won’t stand for his ideologies.”</p><footer class="story-footer story-content">
+                        <div class="story-meta">
+                            <div class="story-notes"><p>Jennifer Medina and Stephanie Saul contributed reporting.</p></div>
+
+
+                            <p class="story-print-citation">A version of this article appears in print on November 10, 2016, on Page P12 of the <span itemprop="printEdition">New York edition</span> with the headline: ‘Not Our President’: Protests Spread. <span class="story-footer-links">  <span><a href="http://www.nytreprints.com/" target="_blank">Order Reprints</a><span class="pipe">|</span></span>  <span><a href="http://www.nytimes.com/pages/todayspaper/index.html" target="_blank">Today's Paper</a><span class="pipe">|</span></span><span><a href="http://www.nytimes.com/subscriptions/Multiproduct/lp839RF.html?campaignId=48JQY" target="_blank">Subscribe</a></span>
+</span>
+                            </p>
+
+                        </div><!-- close story-meta -->
+                    </footer>
+                        <a class="visually-hidden skip-to-text-link" href="#whats-next">Continue reading the main story</a>
+                    </div><!-- close story-body -->
+                    <div class="supplemental " id="supplemental-2">
+                    </div><!-- close supplemental -->
+                </div><!-- close story-body-supplemental -->
+
+
+                <div class="reader-satisfaction-survey prompt feedback-prompt story-content hidden">
+                    <a class="feedback-link" href="https://docs.google.com/forms/d/e/1FAIpQLSfLW30xgZodF1qRAg80oWEGuDpW-1HHaL0g42G3SmvB2f4lCw/viewform?entry.8537735=https://www.nytimes.com/2016/11/10/us/trump-election-protests.html" target="_blank">
+                        <p class="feedback-message">We&#8217;re interested in your feedback on this page. <strong>Tell us what you think.</strong></p>
+                    </a>
+                </div>
+
+                <div id="storage-drawer" class="hidden">
+                    <div class="supplemental-sub-item" data-attribute-position="0" data-attribute-name="CombinedMarginalia" data-attribute-type="Related" data-attribute-subtype="">
+                        <aside class="marginalia related-combined-coverage-marginalia marginalia-item nocontent robots-nocontent" data-marginalia-type="sprinkled" role="complementary" module="Related-CombinedMarginalia">
+                            <div class="nocontent robots-nocontent">
+                                <header>
+                                    <h2 class="module-heading">Related Coverage</h2>
+                                </header>
+                                <ul>
+                                    <li><article class="story theme-summary ">
+                                        <a class="story-link" href="https://www.nytimes.com/2016/11/10/us/trump-election-protest-berkeley-oakland.html">
+
+                                            <div class="thumb">
+                                                <img src="https://static01.nyt.com/images/2016/11/10/us/10trumpprotest/10trumpprotest-thumbStandard.jpg" role="presentation" alt="" />
+                                                <div class="media-action-overlay"></div>
+                                            </div>
+
+                                            <div class="story-body">
+                                                <h2 class="headline">
+                                                    <span class="title">Anti-Trump Demonstrators Take to the Streets in Several U.S. Cities</span>
+                                                    <time class="dateline">NOV. 9, 2016</time>
+                                                </h2>
+                                            </div>
+                                        </a>
+                                    </article>
+                                    </li>
+                                    <li><article class="story theme-summary ">
+                                        <a class="story-link" href="https://www.nytimes.com/video/us/100000004759928/student-protests-break-out-nationwide.html">
+
+                                            <div class="thumb">
+                                                <img src="https://static01.nyt.com/images/2016/11/09/multimedia/10elex-protests/10elex-protests-thumbStandard.jpg" role="presentation" alt="" />
+                                                <div class="media-action-overlay"><i class="icon sprite-icon video-icon"></i>
+                                                    <span class="visually-hidden">video</span>
+                                                </div>
+                                            </div>
+
+                                            <div class="story-body">
+                                                <h2 class="headline">
+                                                    <span class="title">Student Protests Break Out Nationwide</span>
+                                                    <time class="dateline">NOV. 9, 2016</time>
+                                                </h2>
+                                            </div>
+                                        </a>
+                                    </article>
+                                    </li>
+                                    <li><article class="story theme-summary ">
+                                        <a class="story-link" href="https://www.nytimes.com/2016/11/10/us/politics/donald-trump-election-reaction.html">
+
+                                            <div class="thumb">
+                                                <img src="https://static01.nyt.com/images/2016/11/10/us/10SHOCK1/10SHOCK1-thumbStandard.jpg" role="presentation" alt="" />
+                                                <div class="media-action-overlay"></div>
+                                            </div>
+
+                                            <div class="story-body">
+                                                <h2 class="headline">
+                                                    <span class="title">Donald Trump’s Victory Is Met With Shock Across a Wide Political Divide</span>
+                                                    <time class="dateline">NOV. 9, 2016</time>
+                                                </h2>
+                                            </div>
+                                        </a>
+                                    </article>
+                                    </li>
+                                </ul>
+                            </div>
+                        </aside>
+                    </div>
+                    <div class="supplemental-sub-item" data-attribute-position="1" data-attribute-name="PaidPost" data-attribute-type="PaidPost" data-attribute-subtype="">
+                        <aside id='middle-right-paid-post-container' class='ad middle-right-ad paid-post-ad marginalia-item hidden nocontent robots-nocontent'>
+                            <h2 class='marginalia-heading'></h2>
+                            <ul class='story-menu'>
+                                <li id='MiddleRightPaidPost1' class='story-menu-item ad'></li>
+                                <li id='MiddleRightPaidPost2' class='story-menu-item ad'></li>
+                                <li id='MiddleRightPaidPost3' class='story-menu-item ad'></li>
+                                <li id='MiddleRightPaidPost4' class='story-menu-item ad'></li>
+                            </ul>
+                        </aside>
+                    </div>
+                </div>
+
+            </article>
+            <section id="related-combined-coverage" class="related-combined-coverage nocontent robots-nocontent">
+                <header class="section-header">
+                    <h2 class="section-heading">Related Coverage</h2>
+                </header>
+                <div class="section-body">
+                    <ol class="story-menu menu">
+                        <li><article class="story theme-summary ">
+                            <a class="story-link" href="https://www.nytimes.com/2016/11/10/us/trump-election-protest-berkeley-oakland.html">
+                                <div class="story-body">
+                                    <h2 class="headline">
+                                        <span class="title">Anti-Trump Demonstrators Take to the Streets in Several U.S. Cities</span>
+                                        <time class="dateline">NOV. 9, 2016</time>
+                                    </h2>
+                                </div>
+
+                                <div class="thumb">
+                                    <img src="https://static01.nyt.com/images/2016/11/10/us/10trumpprotest/10trumpprotest-thumbStandard.jpg" role="presentation" alt="" />
+                                    <div class="media-action-overlay"></div>
+                                </div>
+                            </a>
+                        </article>
+                        </li>
+                        <li><article class="story theme-summary ">
+                            <a class="story-link" href="https://www.nytimes.com/video/us/100000004759928/student-protests-break-out-nationwide.html">
+                                <div class="story-body">
+                                    <h2 class="headline">
+                                        <span class="title">Student Protests Break Out Nationwide</span>
+                                        <time class="dateline">NOV. 9, 2016</time>
+                                    </h2>
+                                </div>
+
+                                <div class="thumb">
+                                    <img src="https://static01.nyt.com/images/2016/11/09/multimedia/10elex-protests/10elex-protests-thumbStandard.jpg" role="presentation" alt="" />
+                                    <div class="media-action-overlay"><i class="icon sprite-icon video-icon"></i>
+                                        <span class="visually-hidden">video</span>
+                                    </div>
+                                </div>
+                            </a>
+                        </article>
+                        </li>
+                        <li><article class="story theme-summary ">
+                            <a class="story-link" href="https://www.nytimes.com/2016/11/10/us/politics/donald-trump-election-reaction.html">
+                                <div class="story-body">
+                                    <h2 class="headline">
+                                        <span class="title">Donald Trump’s Victory Is Met With Shock Across a Wide Political Divide</span>
+                                        <time class="dateline">NOV. 9, 2016</time>
+                                    </h2>
+                                </div>
+
+                                <div class="thumb">
+                                    <img src="https://static01.nyt.com/images/2016/11/10/us/10SHOCK1/10SHOCK1-thumbStandard.jpg" role="presentation" alt="" />
+                                    <div class="media-action-overlay"></div>
+                                </div>
+                            </a>
+                        </article>
+                        </li>
+                    </ol>
+                </div>
+            </section>
+
+            <!-- While running BundlePayFlow test, hide this module if user is in test) -->
+            <script type="text/javascript">
+                if (window.NYTD && window.NYTD.Abra && window.NYTD.Abra('www-STORY_3bundlePayflow-v3') === '1') {
+                    (function() {
+                        require(['foundation/main'], function () {
+                            require(['jquery/nyt', 'foundation/models/user-data'], function ($, userData) {
+                                if (!userData.hasSynced) {
+                                    userData.on('change', function() {
+                                        checkSubStatus();
+                                    });
+                                } else {
+                                    checkSubStatus();
+                                }
+
+                                function checkSubStatus() {
+                                    if (!userData.isHomeDeliverySubscriber() &&
+                                        !userData.isWebSubscriber() &&
+                                        !userData.isMobileSubscriber() &&
+                                        !userData.isTabletSubscriber()) {
+                                        var relatedCoverage = document.querySelector('.related-combined-coverage');
+                                        if (relatedCoverage && relatedCoverage.parentNode) {
+                                            relatedCoverage.parentNode.removeChild(relatedCoverage);
+                                        }
+                                    }
+                                }
+                            });
+                        });
+                    })();
+                }
+            </script>
+            <section class="module bundle-payflow-module"><div class="bundle-payflow hidden">
+
+                <div class="branding">
+                    <img class="logo" data-src="https://a1.nyt.com/assets/article/20170403-111158/images/foundation/logos/nyt-logo-185x26.svg" alt="The New York Times" />
+                    <div class="header">Discover the truth with us. Select the package that works for you.</div>
+                    <div class="tagline">Choose annual billing and save up to 40% every year. You may cancel anytime.</div>
+                </div><!-- close branding -->
+
+                <div class="bundles-container">
+
+                    <!-- Basic Bundle -->
+                    <a href="https://myaccount.nytimes.com/get-started/auth?OC=20000050400&amp;campaignId=6KJKF" data-oc="20000050400" class="sub-link" data-target="basic">
+                        <div class="bundle-tab basic">
+                            <div class="tab-header">
+                                <div class="title">Basic</div>
+                                <div class="image">
+                                    <img class="the-image" data-src="https://static01.nyt.com/subscriptions/components/img/devices/all-access.png" alt="Basic" />
+                                </div>
+                                <div class="price">$2.75/week</div>
+                                <div class="annual">Billed as $143 every year</div>
+                                <a class="cta-button" href="https://myaccount.nytimes.com/get-started/auth?OC=20000050400&amp;campaignId=6KJKF" data-target="basic" data-oc="20000050400">Get basic</a>
+                            </div><!-- close tab-header -->
+
+                            <div class="feature-header bundle-feature">Basic Digital Access includes:</div>
+
+                            <div class="bundle-feature">
+                                <p class="feature-text bullet">Access to NYTimes.com and all NYTimes apps</p>
+                            </div>
+
+                            <div class="bundle-feature">
+                                <p class="feature-text bullet">Unlimited article access, anytime, anywhere</p>
+                            </div>
+
+                            <div class="bundle-feature">
+                                <p class="feature-text"><a href="https://www.nytimes.com/subscriptions/Multiproduct/lp8HYKU.html?campaignId=6KJKJ" class="learn-more"  data-target="learn-more"><span class="text">Learn more </span><span class="arrow">&#x25BA;</span></a></p>
+                            </div>
+                        </div> <!-- close bundle tab -->
+                    </a> <!-- close bundle link -->
+
+                    <!-- All Access Bundle -->
+                    <a href="https://myaccount.nytimes.com/get-started/auth?OC=20000056980&amp;campaignId=6KJKF" class="sub-link" data-target="all-access" data-oc="20000056980">
+                        <div class="bundle-tab all-access">
+                            <div class="tab-header">
+                                <div class="title">All Access</div>
+                                <div class="image">
+                                    <img class="the-image" data-src="https://static01.nyt.com/subscriptions/components/img/devices/all-access-plus-insider.png" alt="All Access" />
+                                </div>
+                                <div class="price">$3.75/week</div>
+                                <div class="annual">Billed as $195 every year</div>
+                                <a class="cta-button" href="https://myaccount.nytimes.com/get-started/auth?OC=20000056980&amp;campaignId=6KJKF" data-target="all-access" data-oc="20000056980">Get All Access</a>
+                            </div><!-- close tab-header -->
+
+                            <div class="feature-header bundle-feature">Includes everything in Basic, <span class="italic">plus:</span></div>
+
+                            <div class="bundle-feature">
+                                <p class="feature-text bullet">Times Insider Access, including behind-the-scenes stories, exclusive events, podcasts, and e-books</p>
+                            </div>
+
+                            <div class="bundle-feature">
+                                <p class="feature-text bullet">1 complimentary digital subscription to give anyone you'd like</p>
+                            </div>
+                            <div class="bundle-feature">
+                                <p class="feature-text"><a href="https://www.nytimes.com/subscriptions/Multiproduct/lp8HYKU.html?campaignId=6KJKJ" class="learn-more" data-target="learn-more"><span class="text">Learn more </span><span class="arrow">&#x25BA;</span></a></p>
+                            </div>
+                        </div> <!-- close bundle tab -->
+                    </a> <!-- close bundle link -->
+
+                    <!-- Home Delivery Bundle -->
+                    <a href="https://www.nytimes.com/subscriptions/hd/365.html?MediaCode=WB7AA&amp;CMP=6KJKF" class="sub-link" data-target="home-delivery">
+                        <div class="bundle-tab home-delivery">
+                            <div class="tab-header">
+                                <div class="title">Home Delivery<br /><span class="sub-title">+ All Access</span></div>
+                                <div class="image">
+                                    <img class="the-image" data-src="https://static01.nyt.com/subscriptions/components/img/devices/products_hd.png" alt="Home Delivery" />
+                                </div>
+                                <div class="price">$6.93/week</div>
+                                <div class="annual">Billed as $360 every year*</div>
+                                <a class="cta-button" href="https://www.nytimes.com/subscriptions/hd/365.html?MediaCode=WB7AA&amp;CMP=6KJKF" data-target="home-delivery">Get Home Delivery</a>
+                            </div><!-- close tab-header -->
+
+                            <div class="feature-header bundle-feature">Includes everything in All Access, <span class="italic">plus:</span></div>
+
+                            <div class="bundle-feature">
+                                <p class="feature-text bullet">Customized delivery options such as Sunday only, Fri.-Sun., weekday delivery, or daily delivery</p>
+                            </div>
+
+                            <div class="bundle-feature">
+                                <p class="feature-text bullet">The weekly Sunday magazine and monthly T Magazine</p>
+                            </div>
+                            <div class="bundle-feature">
+                                <p class="feature-text bullet">2 complimentary digital subscriptions to give anyone you'd like</p>
+                            </div>
+                            <div class="bundle-feature">
+                                <p class="feature-text"><a href="https://www.nytimes.com/subscriptions/Multiproduct/lp8HYKU.html?campaignId=6KJKJ" class="learn-more" data-target="learn-more"><span class="text">Learn more </span><span class="arrow">&#x25BA;</span></a></p>
+                            </div>
+                        </div> <!-- close bundle tab -->
+                    </a> <!-- close bundle link -->
+
+                </div><!-- close bundle container -->
+
+                <div class="disclaimer">
+                    <div class="text">*Home delivery price based on Sunday delivery.<br>Prices vary based on delivery location and frequency.</div>
+                </div>
+
+            </div> <!-- end bundle-payflow -->
+
+            </section>
+
+
+            <aside class="module trending-module hidden nocontent robots-nocontent" data-truncate-enabled="true"></aside><section id="whats-next" class="whats-next nocontent robots-nocontent">
+            <h2 class="visually-hidden">What's Next</h2>
+            <div class="nocontent robots-nocontent">
+                <div class="loader-container">
+                    <div class="loader loader-t-logo-32x32-ecedeb-ffffff"><span class="visually-hidden">Loading...</span></div>
+                </div>
+            </div><!-- close nocontent -->
+        </section>
+            <div id="TopAd1" class="text-ad bottom-left-ad nocontent robots-nocontent"></div>
+            <div id="Top5" class="ad top5-ad hidden nocontent robots-nocontent"></div>
+            <div class="search-overlay"></div>
+        </main><!-- close main -->
+        <section id="site-index" class="site-index">
+            <header class="section-header">
+                <p class="user-action"><a href="http://www.nytimes.com/">Go to Home Page &raquo;</a></p>
+                <h2 class="section-heading">
+                    <span class="visually-hidden">Site Index</span>
+                    <a id="site-index-branding-link" href="http://www.nytimes.com/">
+                        <span class="visually-hidden">The New York Times</span>
+                    </a>
+                </h2>
+                <script>window.magnum.writeLogo('small', 'https://a1.nyt.com/assets/article/20170403-111158/images/foundation/logos/', '', '', 'standard', 'site-index-branding-link', '');</script>
+            </header>
+
+            <nav id="site-index-navigation" class="site-index-navigation" role="navigation">
+                <h2 class="visually-hidden">Site Index Navigation</h2>
+                <div class="split-6-layout layout">
+
+
+                    <div class="column">
+                        <h3 class="menu-heading">News</h3>
+                        <ul class="menu">
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/world/index.html">World</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/national/index.html">U.S.</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/politics/index.html">Politics</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/nyregion/index.html">N.Y.</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/business/index.html">Business</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/technology/index.html">Tech</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/section/science">Science</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/health/index.html">Health</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/sports/index.html">Sports</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/education/index.html">Education</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/obituaries/index.html">Obituaries</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/todayspaper/index.html">Today's Paper</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/corrections/index.html">Corrections</a>
+                            </li>
+
+
+                        </ul>
+                    </div><!-- close column -->
+
+
+                    <div class="column">
+                        <h3 class="menu-heading">Opinion</h3>
+                        <ul class="menu">
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/opinion/index.html">Today's Opinion</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/opinion/index.html#columnists">Op-Ed Columnists</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/opinion/index.html#editorials">Editorials</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/opinion/index.html#contributing">Contributing Writers</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/opinion/index.html#op-ed">Op-Ed Contributors</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/opinion/index.html#opinionator">Opinionator</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/opinion/index.html#letters">Letters</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/opinion/index.html#sundayreview">Sunday Review</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/opinion/index.html#takingNote">Taking Note</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/roomfordebate">Room for Debate</a>
+                            </li>
+
+
+                            <li>
+                                <a href="http://topics.nytimes.com/top/opinion/thepubliceditor/index.html">Public Editor</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/video/opinion">Video: Opinion</a>
+                            </li>
+
+
+                        </ul>
+                    </div><!-- close column -->
+
+
+                    <div class="column">
+                        <h3 class="menu-heading">Arts</h3>
+                        <ul class="menu">
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/arts/index.html">Today's Arts</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/arts/design/index.html">Art & Design</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/books/index.html">Books</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/arts/dance/index.html">Dance</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/movies/index.html">Movies</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/arts/music/index.html">Music</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/events/">N.Y.C. Events Guide</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/arts/television/index.html">Television</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/theater/index.html">Theater</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/video/arts">Video: Arts</a>
+                            </li>
+
+
+                        </ul>
+                    </div><!-- close column -->
+
+
+                    <div class="column">
+                        <h3 class="menu-heading">Living</h3>
+                        <ul class="menu">
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/automobiles/index.html">Automobiles</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/crosswords/">Crossword</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/dining/index.html">Food</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/education/index.html">Education</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/fashion/index.html">Fashion & Style</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/health/index.html">Health</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/section/jobs">Jobs</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/magazine/index.html">Magazine</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/events/">N.Y.C. Events Guide</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/section/realestate">Real Estate</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/section/t-magazine">T Magazine</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/section/travel">Travel</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/fashion/weddings/index.html">Weddings & Celebrations</a>
+                            </li>
+
+
+                        </ul>
+                    </div><!-- close column -->
+
+
+                    <div class="column">
+                        <h3 class="menu-heading">Listings & More</h3>
+                        <ul class="menu">
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/ref/classifieds/">Classifieds</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/marketing/tools-and-services/">Tools & Services</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/topics/">Times Topics</a>
+                            </li>
+
+
+                            <li>
+                                <a href="http://topics.nytimes.com/top/opinion/thepubliceditor/index.html">Public Editor</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/events/">N.Y.C. Events Guide</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/interactive/blogs/directory.html">Blogs</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/multimedia/index.html">Multimedia</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://lens.blogs.nytimes.com/">Photography</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/video">Video</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/store/?&t=qry542&utm_source=nytimes&utm_medium=HPB&utm_content=hp_browsetree&utm_campaign=NYT-HP&module=SectionsNav&action=click&region=TopBar&version=BrowseTree&contentCollection=NYT%20Store&contentPlacement=2&pgtype=Homepage">NYT Store</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/times-journeys/?utm_source=nytimes&utm_medium=HPLink&utm_content=hp_browsetree&utm_campaign=NYT-HP">Times Journeys</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/seeallnav">Subscribe</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/membercenter">Manage My Account</a>
+                            </li>
+
+
+                        </ul>
+                    </div><!-- close column -->
+
+
+                    <div class="column last-column">
+
+                        <h3 class="menu-heading">Subscribe</h3>
+
+                        <ul class="menu primary-menu">
+                            <li class="menu-label">Subscribe</li>
+                            <li class="home-delivery">
+                                <i class="icon sprite-icon"></i>
+                                <a href="http://www.nytimes.com/hdleftnav">Home Delivery</a>
+                            </li>
+                            <li class="digital-subscriptions">
+                                <i class="icon sprite-icon"></i>
+                                <a href="http://www.nytimes.com/digitalleftnav">Digital Subscriptions</a>
+                            </li>
+                            <li class="times-premier">
+                                <i class="icon sprite-icon"></i>
+                                <a href="http://www.nytimes.com/tpnav">Times Insider</a>
+                            </li>
+                            <li class="nyt-crossword last-item">
+                                <i class="icon sprite-icon"></i>
+                                <a id="nyt-crossword" href="http://www.nytimes.com/crosswords/index.html">Crossword</a>
+                            </li>
+                        </ul>
+
+                        <ul class="menu secondary-menu">
+
+                            <li>
+                                <a href="http://www.nytimes.com/marketing/newsletters">Email Newsletters</a>
+                            </li>
+                            <li>
+                                <a href="https://myaccount.nytimes.com/mem/tnt.html">Alerts</a>
+                            </li>
+                            <li>
+                                <a href="http://www.nytimes.com/giftleftnav">Gift Subscriptions</a>
+                            </li>
+                            <li>
+                                <a href="http://www.nytimes.com/corporateleftnav">Corporate Subscriptions</a>
+                            </li>
+                            <li>
+                                <a href="http://www.nytimes.com/educationleftnav">Education Rate</a>
+                            </li>
+
+                        </ul>
+                        <ul class="menu secondary-menu">
+                            <li>
+                                <a href="http://www.nytimes.com/services/mobile/index.html">Mobile Applications</a>
+                            </li>
+                            <li>
+                                <a href="http://eedition.nytimes.com/cgi-bin/signup.cgi?cc=37FYY">Replica Edition</a>
+                            </li>
+
+                        </ul>
+
+                    </div><!-- close column -->
+
+                </div><!-- close split-6-layout -->
+
+            </nav><!-- close nav -->
+
+        </section><!-- close site-index -->
+
+        <footer id="page-footer" class="page-footer" role="contentinfo">
+            <nav>
+                <h2 class="visually-hidden">Site Information Navigation</h2>
+                <ul>
+                    <li>
+                        <a href="http://www.nytimes.com/content/help/rights/copyright/copyright-notice.html" itemprop="copyrightNotice">
+                            &copy; <span itemprop="copyrightYear">2017</span><span itemprop="copyrightHolder provider sourceOrganization" itemscope itemtype="http://schema.org/Organization" itemid="http://www.nytimes.com"><span itemprop="name"> The New York Times Company</span><meta itemprop="tickerSymbol" content="NYSE NYT"/></span>
+                        </a>
+                    </li>
+                    <li class="visually-hidden"><a href="http://www.nytimes.com">Home</a></li>
+                    <li class="visually-hidden"><a href="http://query.nytimes.com/search/sitesearch/#/">Search</a></li>
+                    <li class="visually-hidden">Accessibility concerns? Email us at <a href="mailto:accessibility@nytimes.com">accessibility@nytimes.com</a>. We would love to hear from you.</li>
+                    <li class="wide-viewport-item"><a href="http://www.nytimes.com/ref/membercenter/help/infoservdirectory.html">Contact Us</a></li>
+                    <li class="wide-viewport-item"><a href="http://www.nytco.com/careers">Work With Us</a></li>
+                    <li class="wide-viewport-item"><a href="http://nytmediakit.com/">Advertise</a></li>
+                    <li class="wide-viewport-item"><a href="http://www.nytimes.com/content/help/rights/privacy/policy/privacy-policy.html#pp">Your Ad Choices</a></li>
+                    <li><a href="http://www.nytimes.com/privacy">Privacy</a></li>
+                    <li><a href="http://www.nytimes.com/ref/membercenter/help/agree.html" itemprop="usageTerms">Terms of Service</a></li>
+                    <li class="wide-viewport-item last-item"><a href="http://www.nytimes.com/content/help/rights/sale/terms-of-sale.html">Terms of Sale</a></li>
+                </ul>
+            </nav>
+            <nav class="last-nav">
+                <h2 class="visually-hidden">Site Information Navigation</h2>
+                <ul>
+                    <li><a href="http://spiderbites.nytimes.com">Site Map</a></li>
+                    <li><a href="http://www.nytimes.com/membercenter/sitehelp.html">Help</a></li>
+                    <li><a href="https://myaccount.nytimes.com/membercenter/feedback.html">Site Feedback</a></li>
+                    <li class="wide-viewport-item last-item"><a href="http://www.nytimes.com/subscriptions/Multiproduct/lp5558.html?campaignId=37WXW">Subscriptions</a></li>
+                </ul>
+            </nav>
+        </footer>
+    </div><!-- close page -->
+</div><!-- close shell -->
+<script src="https://cdn.optimizely.com/public/3013110282/s/article_prod.js" type="text/javascript" async></script>
+<script>
+    require(['foundation/main'], function () {
+        require(['story/main']);
+        require(['jquery/nyt', 'foundation/views/page-manager'], function ($, pageManager) {
+            if (window.location.search.indexOf('disable_tagx') > 0) {
+                return;
+            }
+            $(document).ready(function () {
+                require(['https://a1.nyt.com/analytics/tagx-simple.min.js'], function () {
+                    pageManager.trackingFireEventQueue();
+                });
+            });
+        });
+    });
+</script>
+<!--esi
+<esi:include src="/appconfig/https/show-modal.js" />
+-->
+
+<div id="Inv1" class="ad inv1-ad hidden"></div>
+<div id="Inv2" class="ad inv2-ad hidden"></div>
+<div id="Inv3" class="ad inv3-ad hidden"></div>
+<div id="ab1" class="ad ab1-ad hidden"></div>
+<div id="ab2" class="ad ab2-ad hidden"></div>
+<div id="ab3" class="ad ab3-ad hidden"></div>
+<div id="prop1" class="ad prop1-ad hidden"></div>
+<div id="prop2" class="ad prop2-ad hidden"></div>
+<div id="Anchor" class="ad anchor-ad hidden"></div>
+<div id="ADX_CLIENTSIDE" class="ad adx-clientside-ad hidden"></div>
+</body>
+</html>
+
+<!DOCTYPE html>
+<!--[if (gt IE 9)|!(IE)]> <!--> <html lang="en" class="no-js section-us format-medium tone-news app-article page-theme-standard has-top-ad type-size-small has-large-lede" itemid="https://www.nytimes.com/2016/11/10/us/trump-election-protests.html" itemtype="http://schema.org/NewsArticle"  itemscope xmlns:og="http://opengraphprotocol.org/schema/"> <!--<![endif]-->
+<!--[if IE 9]> <html lang="en" class="no-js ie9 lt-ie10 section-us format-medium tone-news app-article page-theme-standard has-top-ad type-size-small has-large-lede" xmlns:og="http://opengraphprotocol.org/schema/"> <![endif]-->
+<!--[if IE 8]> <html lang="en" class="no-js ie8 lt-ie10 lt-ie9 section-us format-medium tone-news app-article page-theme-standard has-top-ad type-size-small has-large-lede" xmlns:og="http://opengraphprotocol.org/schema/"> <![endif]-->
+<!--[if (lt IE 8)]> <html lang="en" class="no-js lt-ie10 lt-ie9 lt-ie8 section-us format-medium tone-news app-article page-theme-standard has-top-ad type-size-small has-large-lede" xmlns:og="http://opengraphprotocol.org/schema/"> <![endif]-->
+<head>
+    <title>‘Not Our President’: Protests Spread After Donald Trump’s Election - The New York Times</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+    <link rel="shortcut icon" href="https://static01.nyt.com/favicon.ico" />
+    <link rel="apple-touch-icon-precomposed" sizes="144×144" href="https://static01.nyt.com/images/icons/ios-ipad-144x144.png" />
+    <link rel="apple-touch-icon-precomposed" sizes="114×114" href="https://static01.nyt.com/images/icons/ios-iphone-114x144.png" />
+    <link rel="apple-touch-icon-precomposed" href="https://static01.nyt.com/images/icons/ios-default-homescreen-57x57.png" />
+    <meta name="sourceApp" content="nyt-v5" />
+    <meta id="applicationName" name="applicationName" content="article" />
+    <meta id="foundation-build-id" name="foundation-build-id" content="" />
+    <link rel="canonical" href="https://www.nytimes.com/2016/11/10/us/trump-election-protests.html" />
+    <link rel="alternate" media="only screen and (max-width: 640px)" href="http://mobile.nytimes.com/2016/11/10/us/trump-election-protests.html" />
+    <link rel="alternate" media="handheld" href="http://mobile.nytimes.com/2016/11/10/us/trump-election-protests.html" />
+    <link rel="amphtml" href="https://mobile.nytimes.com/2016/11/10/us/trump-election-protests.amp.html" />
+    <meta property="al:android:url" content="nytimes://reader/id/100000004760134" />
+    <meta property="al:android:package" content="com.nytimes.android" />
+    <meta property="al:android:app_name" content="NYTimes" />
+    <meta name="twitter:app:name:googleplay" content="NYTimes" />
+    <meta name="twitter:app:id:googleplay" content="com.nytimes.android" />
+    <meta name="twitter:app:url:googleplay" content="nytimes://reader/id/100000004760134" />
+    <link rel="alternate" href="android-app://com.nytimes.android/nytimes/reader/id/100000004760134" />
+    <meta property="al:iphone:url" content="nytimes://www.nytimes.com/2016/11/10/us/trump-election-protests.html" />
+    <meta property="al:iphone:app_store_id" content="284862083" />
+    <meta property="al:iphone:app_name" content="NYTimes" />
+    <meta property="al:ipad:url" content="nytimes://www.nytimes.com/2016/11/10/us/trump-election-protests.html" />
+    <meta property="al:ipad:app_store_id" content="357066198" />
+    <meta property="al:ipad:app_name" content="NYTimes" />
+    <meta name="robots" content="noarchive" />
+    <meta itemprop="alternativeHeadline" name="hdl_p" content="‘Not Our President’: Protests Spread" />
+    <meta name="channels" content="" />
+    <meta itemprop="description" name="description" content="Demonstrators marched through Manhattan toward Trump Tower, and similar protests took place in other cities and on college campuses across the country." />
+    <meta name="genre" itemprop="genre" content="News" />
+    <meta itemprop="identifier" name="articleid" content="100000004760134" />
+    <meta itemprop="usageTerms" name="usageTerms" content="http://www.nytimes.com/content/help/rights/sale/terms-of-sale.html" />
+    <meta itemprop="inLanguage" content="en-US" />
+    <meta name="hdl" content="‘Not Our President’: Protests Spread After Donald Trump’s Election" />
+    <meta name="col" content="" id="column-name" />
+    <meta name="pdate" content="20161109" />
+    <meta name="utime" content="20170228080206" />
+    <meta name="ptime" content="20161109211306" />
+    <meta name="DISPLAYDATE" content="Nov. 9, 2016" />
+    <meta name="dat" content="Nov. 9, 2016" />
+    <meta name="lp" content="Demonstrators marched through Manhattan toward Trump Tower, and similar protests took place in other cities and on college campuses across the country." />
+    <meta name="msapplication-starturl" content="http://www.nytimes.com" />
+    <meta name="cre" content="The New York Times" />
+    <meta name="slug" content="10xp-protests" />
+    <meta property="article:collection" content="https://static01.nyt.com/services/json/sectionfronts/us/index.jsonp" />
+    <meta name="sectionfront_jsonp" content="https://static01.nyt.com/services/json/sectionfronts/us/index.jsonp" />
+    <meta property="og:url" content="https://www.nytimes.com/2016/11/10/us/trump-election-protests.html" />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="‘Not Our President’: Protests Spread After Donald Trump’s Election" />
+    <meta property="og:description" content="Demonstrators marched through Manhattan toward Trump Tower, and similar protests took place in other cities and on college campuses across the country." />
+    <meta property="article:published" itemprop="datePublished" content="2016-11-09T21:13:06-05:00" />
+    <meta property="article:modified" itemprop="dateModified" content="2017-02-28T08:02:06-05:00" />
+    <meta property="article:section" itemprop="articleSection" content="U.S." />
+    <meta property="article:section-taxonomy-id" itemprop="articleSection" content="23FD6C8B-62D5-4CEA-A331-6C2A9A1223BE" />
+    <meta property="article:section_url" content="https://www.nytimes.com/section/us" />
+    <meta property="article:top-level-section" content="us" />
+    <meta property="fb:app_id" content="9869919170" />
+    <meta name="twitter:site" value="@nytimes" />
+    <meta property="twitter:url" content="https://www.nytimes.com/2016/11/10/us/trump-election-protests.html" />
+    <meta property="twitter:title" content="‘Not Our President’: Protests Spread After Donald Trump’s Election" />
+    <meta property="twitter:description" content="Demonstrators marched through Manhattan toward Trump Tower, and similar protests took place in other cities and on college campuses across the country." />
+    <meta name="author" content="Christopher Mele and Annie Correal" />
+    <meta name="tone" content="news" id="article-tone" />
+    <meta name="byl" content="By CHRISTOPHER MELE and ANNIE CORREAL" />
+    <meta name="PT" content="article" />
+    <meta name="CG" content="us" />
+    <meta name="SCG" content="" />
+    <meta name="PST" content="News" />
+    <meta name="tom" content="News" />
+    <meta name="edt" content="NewYork" />
+    <meta property="og:image" content="https://static01.nyt.com/images/2016/11/11/us/11attack2_xp/11attack2_xp-facebookJumbo.jpg" />
+    <meta property="twitter:image:alt" content="A pro-Trump supporter, right, attacked an anti-Trump protester at Lee Circle after the protester grabbed his Trump flag from the truck in New Orleans, on Wednesday." />
+    <meta property="twitter:image" content="https://static01.nyt.com/images/2016/11/11/us/11attack2_xp/11attack2_xp-thumbLarge.jpg" />
+    <meta name="twitter:card" value="summary" />
+    <meta property="article:author" content="https://www.nytimes.com/by/christopher-mele" />
+    <meta property="article:author" content="https://www.nytimes.com/by/annie-correal" />
+    <meta property="article:tag" content="Presidential Election of 2016" />
+    <meta name="des" content="Presidential Election of 2016" />
+    <meta property="article:tag" content="Demonstrations, Protests and Riots" />
+    <meta name="des" content="Demonstrations, Protests and Riots" />
+    <meta property="article:tag" content="Trump, Donald J" />
+    <meta name="per" content="Trump, Donald J" />
+    <meta name="keywords" content="Presidential Election of 2016,Demonstrations  Protests and Riots,Trump  Donald J" />
+    <meta name="news_keywords" content="2016 Presidential Election,Civil Unrest,Donald Trump" />
+    <meta name="thumbnail_150" content="https://static01.nyt.com/images/2016/11/11/us/11attack2_xp/11attack2_xp-thumbLarge.jpg" />
+    <meta name="thumbnail_150_height" content="150" />
+    <meta name="thumbnail_150_width" content="150" />
+    <meta itemprop="thumbnailUrl" name="thumbnail" content="https://static01.nyt.com/images/2016/11/11/us/11attack2_xp/11attack2_xp-thumbStandard.jpg" />
+    <meta name="thumbnail_height" content="75" />
+    <meta name="thumbnail_width" content="75" />
+    <meta name="video:playerId" content="2640832222001" />
+    <meta name="video:noShareToolsPlayerId" content="3692909326001" />
+    <meta name="video:publisherId" content="1749339200" />
+    <meta name="video:publisherReadToken" content="cE97ArV7TzqBzkmeRVVhJ8O6GWME2iG_bRvjBTlNb4o." />
+    <meta name="dfp-ad-unit-path" content="us" />
+    <meta name="dfp-amazon-enabled" content="false" />
+    <link rel="alternate" type="application/json+oembed" href="https://www.nytimes.com/svc/oembed/json/?url=https%3A%2F%2Fwww.nytimes.com%2F2016%2F11%2F10%2Fus%2Ftrump-election-protests.html" title="‘Not Our President’: Protests Spread After Donald Trump’s Election" />
+
+    <link id="legacy-zam5nzz" rel="stylesheet" type="text/css" href="https://typeface.nyt.com/css/zam5nzz.css" media="all" />
+    <!--[if (gt IE 9)|!(IE)]> <!-->
+    <link rel="stylesheet" type="text/css" media="screen" href="https://a1.nyt.com/assets/article/20170403-111158/css/article/story/styles.css" />
+    <!--<![endif]-->
+    <!--[if lte IE 9]>
+    <link rel="stylesheet" type="text/css" media="screen" href="https://a1.nyt.com/assets/article/20170403-111158/css/article/story/styles-ie.css" />
+    <![endif]-->
+    <link rel="stylesheet" type="text/css" media="print" href="https://a1.nyt.com/assets/article/20170403-111158/css/article/story/styles-print.css" />
+    <!--  begin abra  -->
+    <script>
+        var NYTD=NYTD||{};NYTD.Abra=function(t){"use strict";function n(t){var n=a[t];return n&&n[1]||null}function e(t,n){if(t){var e,o,r=n[0],a=n[1],u=0,c=0;if(1!==a.length||4294967296!==a[0])for(e=i(t+" "+r)>>>0,u=0,c=0;o=a[u++];)if(e<(c+=o[0]))return o}}function o(n,e,o,i){s+="subject="+n+"&test="+encodeURIComponent(e)+"&variant="+encodeURIComponent(o||0)+"&url="+encodeURIComponent(t.location.href)+"&instant=1&skipAugment=true\n",i&&f.push(i),c||(c=t.setTimeout(r,0))}function r(){var n=new t.XMLHttpRequest,e=f;n.withCredentials=!0,n.open("POST",u),n.onreadystatechange=function(){var t,o;if(4==n.readyState)for(t=200==n.status?null:new Error(n.statusText);o=e.shift();)o(t)},n.send(s),s="",f=[],c=null}function i(t){for(var n,e,o,r,i,a,u,c=0,s=0,f=[],l=[n=1732584193,e=4023233417,~n,~e,3285377520],h=[],p=t.length;s<=p;)h[s>>2]|=(s<p?t.charCodeAt(s):128)<<8*(3-s++%4);for(h[u=p+8>>2|15]=p<<3;c<=u;c+=16){for(n=l,s=0;s<80;n=[0|[(a=((t=n[0])<<5|t>>>27)+n[4]+(f[s]=s<16?~~h[c+s]:a<<1|a>>>31)+1518500249)+((e=n[1])&(o=n[2])|~e&(r=n[3])),i=a+(e^o^r)+341275144,a+(e&o|e&r|o&r)+882459459,i+1535694389][0|s++/20],t,e<<30|e>>>2,o,r])a=f[s-3]^f[s-8]^f[s-14]^f[s-16];for(s=5;s;)l[--s]=l[s]+n[s]|0}return l[0]}var a,u,c,s="",f=[];return n.init=function(n,r){var i,c,s,f,l,h=[],p=(t.document.cookie.match(/(^|;) *nyt-a=([^;]*)/)||[])[2],d=(t.document.cookie.match(/(^|;) *ab7=([^;]*)/)||[])[2],m=new RegExp("[?&]abra(=([^&#]*))"),g=m.exec(t.location.search);if(g&&g[2]&&(d=d?g[2]+"&"+d:g[2]),a)throw new Error("can't init twice");if(u=r,a={},d)for(d=decodeURIComponent(d).split("&"),i=0;i<d.length;i++)l=d[i].split("="),l[0]in a||(a[l[0]]=[,l[1]],l[1]&&h.push(l[0]+"="+l[1]));for(i=0;i<n.length;i++)s=n[i],c=s[0],c in a||(f=e(p,s)||[],a[c]=f,f[1]&&h.push(c.replace(/[^\w-]/g)+"="+(""+f[1]).replace(/[^\w-]/g)),f[2]&&o("ab-alloc",c,f[1]));h.length&&t.document.documentElement.setAttribute("data-nyt-ab",h.join(" "))},n.reportExposure=function(n,e){var r=a[n];r&&r[2]?o("ab-expose",n,r[1],e):e&&t.setTimeout(function(){e(null)},0)},n}(this);
+    </script>
+    <script>NYTD.Abra.init([["www-story-reader-satisfaction",[[21474837,"Control",1],[21474836,"VariantA",1],[4252017623,null,0]]],["www-signup-favor-test",[[2147483648,"0",1],[2147483648,"1",1]]],["www-fixed-nav-subscribe-test",[[4294967296,"1",1]]],["www-ad-diagnostic",[[21474837,"1",0],[4273492459,null,0]]],["www-fabrik-off",[[4294967296,"1",1]]],["www-auto-newsletter",[[4294967296,"1",1]]],["www-follow-test-1",[[4080218932,"control",1],[214748364,"variant",1]]],["www-STORY_3bundlePayflow-v3",[[2147483648,"control",1],[2147483648,"1",1]]],["www-story-1427-ad-aggro",[[42949673,"control",1],[42949673,"10",1],[42949673,"8",1],[42949673,"6",1],[42949673,"4",1],[42949673,"pro-10",1],[42949673,"pro-8",1],[42949673,"pro-6",1],[42949673,"pro-4",1],[3908420239,null,0]]],["EC_SampleTest",[[2147483648,"variantA",0],[2147483648,"variantB",0]]],["EC_DigiAbandonmentTest",[[4294967296,"sendAbandonmentEmail",1]]],["EC_HdAbandonmentTest",[[2147483648,"control",1],[2147483648,"sendAbandonmentEmail",1]]],["EC_CrosswordsUpsellTest",[[2147483648,"control",1],[2147483648,"upsell",1]]],["mapleFreeTrial",[[1073741824,"0",1],[1073741824,"1",1],[1073741824,"2",1],[1073741824,"3",1]]],["EC_NewSubOnboardingTest",[[2147483648,"control",1],[2147483648,"sov1",1]]],["PaywallAU",[[1417339208,"0",1],[1417339208,"1",1],[1460288880,"2",1]]]], '//et.nytimes.com/')</script>
+    <!--  end abra  -->
+    <script id="page-config-data" type="text/json">
+{"pageconfig":{"ledeMediaSize":"large","keywords":["article-medium"],"collections":{"sections":["newyork","us","politics"],"syndicated":["apple","facebook"]}}}</script>
+    <script id="display_overrides">
+        []    </script>
+
+    <!-- Media.net Initialization Script -->
+    <!--NY times Desktop-->
+    <script type="text/javascript">
+        var googletag = googletag || {};
+        googletag.cmd = googletag.cmd || [];
+        (function () {
+            window.advBidxc = window.advBidxc || {};
+            window.advBidxc.renderAd = function () {};
+            window.advBidxc.startTime = new Date().getTime();
+            window.advBidxc.customerId = "8CU2553YN"; //Media.net Customer ID
+            window.advBidxc.timeout = 300;
+            function loadScript(tagSrc) {
+                if (tagSrc.substr(0, 4) !== 'http') {
+                    var isSSL = 'https:' == document.location.protocol;
+                    tagSrc = (isSSL ? 'https:' : '') + tagSrc;
+                }
+                var scriptTag = document.createElement('script'),
+                    placeTag = document.getElementsByTagName("script")[0];
+                scriptTag.type = 'text/javascript';
+                scriptTag.async = true;
+                scriptTag.src = tagSrc;
+                placeTag.parentNode.insertBefore(scriptTag, placeTag);
+            }
+
+            function loadGPT() {
+                if (!window.advBidxc.isAdServerLoaded) {
+                    loadScript('//www.googletagservices.com/tag/js/gpt.js');
+                    window.advBidxc.isAdServerLoaded = true;
+                }
+            }
+
+            window.advBidxc.loadGPT = setTimeout(loadGPT, window.advBidxc.timeout);
+        })();
+    </script>
+    <script src="https://contextual.media.net/bidexchange.js?cid=8CU2553YN&amp;https=1"></script>
+
+    <!-- A9 Initialization Script -->
+    <script type="text/javascript">
+        var amznads = amznads || {};
+        amznads.asyncParams = {
+            'id': '3030',
+            'callbackFn': function() {
+                try {
+                    amznads.setTargetingForGPTAsync('amznslots');
+                } catch (e) { }
+            },
+            'timeout': 1000
+        };
+
+        (function() {
+            var a, s = document.getElementsByTagName("script")[0];
+            a = document.createElement("script");
+            a.type = "text/javascript";
+            a.async = true;
+            a.src = "https://c.amazon-adsystem.com/aax2/amzn_ads.js";
+            s.parentNode.insertBefore(a, s);
+        })();
+    </script>
+    <script type="text/json" id="trending-link-json">
+    </script>
+
+    <!--esi
+    <script id="user-info-data" type="application/json">
+    <esi:include src="/svc/web-products/userinfo-v3.json" />
+    </script>
+    -->
+    <script id="magnum-feature-flags" type="application/json">["limitFabrikSave","moreFollowSuggestions","unfollowComments","scoopTool","videoVHSCover","videoVHSShareTools","videoVHSLive","videoVHSNewControls","videoVHSEmbeddedOnly","allTheEmphases","freeTrial","dedupeWhatsNext","trendingPageLinks","sprinklePaidPost","headerBidder","standardizeWhatsNextCollection","onlyLayoutA","simple","simpleExtendedByline","collectionsWhatsNext","mobileMediaViewer","podcastInLede","MovieTickets","MoreInSubsectionFix","seriesIssueMarginalia","serverSideCollectionUrls","multipleBylines","fabrikWebsocketsOnly","translationLinks","papihttps","verticalFullBleed","updateRestaurantReservations","mapDining","newsletterInlineModule","PersonalizationApiUpdate","a9HeaderEnabled","removeInternationalEdition","headlineBalancer","clientSideABRA","newsletterTitleTracking","surveyInterstitial","removeFBMessengerPromo","removeMarginaliaAbTest","paidpostSprinklingFix","abraOverrideVersion","headlineBalancerEverywhere","signupFavor","lazyloadOakImages","mapleFreeTrial","adQuerySupportForMultipleUserAddedKeywords","removeSectionDependentAdLogicForJanuary","oakUpdateAdStride","autoPlaceNewsletter","piiBlockDFP","adExclusiveIERibbonCheck","FlexAdDoubleHeightTracking","didScroll","supportedByAdFullBleed","anchorsHttps","oakBylineMargin","TopFlexAdSiteWide","BundlePayFlow","loadArticleOptimizely","oakStyleTouchups","oakBasicHeader","story1427AdAggro","story1427AdAggroTracking"]</script>
+    <script>
+        var require = {
+            baseUrl: 'https://a1.nyt.com/assets/',
+            waitSeconds: 20,
+            paths: {
+                'foundation': 'article/20170403-111158/js/foundation',
+                'shared': 'article/20170403-111158/js/shared',
+                'article': 'article/20170403-111158/js/article',
+                'application': 'article/20170403-111158/js/article/story',
+                'videoFactory': 'https://static01.nyt.com/js2/build/video/2.0/videofactoryrequire',
+                'videoPlaylist': 'https://static01.nyt.com/js2/build/video/players/extended/2.0/appRequire',
+                'auth/mtr': 'https://static01.nyt.com/js/mtr',
+                'auth/growl': 'https://static01.nyt.com/js/auth/growl/default',
+                'vhs': 'https://static01.nyt.com/video/vhs/build/vhs-2.x.min'
+            },
+            map: {
+                '*': {
+                    'story/main': 'article/story/main'
+                }
+            }
+        };
+    </script>
+    <!--[if (gte IE 9)|!(IE)]> <!-->
+    <script data-main="foundation/main" src="https://a1.nyt.com/assets/article/20170403-111158/js/foundation/lib/framework.js"></script>
+    <!--<![endif]-->
+    <!--[if lt IE 9]>
+    <script>
+        require.map['*']['foundation/main'] = 'foundation/legacy_main';
+    </script>
+    <script data-main="foundation/legacy_main" src="https://a1.nyt.com/assets/article/20170403-111158/js/foundation/lib/framework.js"></script>
+    <![endif]-->
+    <script>
+        require(['foundation/main'], function () {
+            require(['auth/mtr', 'auth/growl']);
+        });
+    </script>
+</head>
+
+<body>
+
+<style>
+    .lt-ie10 .messenger.suggestions {
+        display: block !important;
+        height: 50px;
+    }
+
+    .lt-ie10 .messenger.suggestions .message-bed {
+        background-color: #f8e9d2;
+        border-bottom: 1px solid #ccc;
+    }
+
+    .lt-ie10 .messenger.suggestions .message-container {
+        padding: 11px 18px 11px 30px;
+    }
+
+    .lt-ie10 .messenger.suggestions .action-link {
+        font-family: "nyt-franklin", arial, helvetica, sans-serif;
+        font-size: 10px;
+        font-weight: bold;
+        color: #a81817;
+        text-transform: uppercase;
+    }
+
+    .lt-ie10 .messenger.suggestions .alert-icon {
+        background: url('https://static01.nyt.com/images/icons/icon-alert-12x12-a81817.png') no-repeat;
+        width: 12px;
+        height: 12px;
+        display: inline-block;
+        margin-top: -2px;
+        float: none;
+    }
+
+    .lt-ie10 .masthead,
+    .lt-ie10 .navigation,
+    .lt-ie10 .comments-panel {
+        margin-top: 50px !important;
+    }
+
+    .lt-ie10 .ribbon {
+        margin-top: 97px !important;
+    }
+</style>
+<div id="suggestions" class="suggestions messenger nocontent robots-nocontent" style="display:none;">
+    <div class="message-bed">
+        <div class="message-container last-message-container">
+            <div class="message">
+                <span class="message-content">
+                    <i class="icon alert-icon"></i><span class="message-title">NYTimes.com no longer supports Internet Explorer 9 or earlier. Please upgrade your browser.</span>
+                    <a href="http://www.nytimes.com/content/help/site/ie9-support.html" class="action-link">LEARN MORE »</a>
+                </span>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div id="shell" class="shell">
+    <header id="masthead" class="masthead masthead-theme-standard" role="banner">
+        <div class="container">
+            <div class="quick-navigation button-group">
+                <button class="button sections-button"><i class="icon sprite-icon"></i><span class="button-text">Sections</span></button>
+                <button class="button home-button" data-href="http://www.nytimes.com/" title="Go to the home page to see the latest top stories."><i class="icon sprite-icon"></i>
+                    <span class="button-text">Home</span>
+                </button>
+                <button class="button search-button"><i class="icon sprite-icon"></i><span class="button-text">Search</span></button>
+                <a class="button skip-button skip-to-content visually-hidden focusable" href="#story-header">Skip to content</a>
+                <a class="button skip-button skip-to-navigation visually-hidden focusable" href="#site-index-navigation">Skip to navigation</a>
+                <a class="button skip-button skip-to-mobile visually-hidden focusable" href="http://mobile.nytimes.com/2016/11/10/us/trump-election-protests.html">View mobile version</a>
+            </div><!-- close button-group -->
+            <div class="branding">
+                <h2 class="branding-heading">
+                    <a id="branding-heading-link" href="http://www.nytimes.com/">
+                        <span class="visually-hidden">The New York Times</span>
+                    </a>
+                </h2>
+                <script>window.magnum.writeLogo('small', 'https://a1.nyt.com/assets/article/20170403-111158/images/foundation/logos/', 'us', 'masthead-theme-standard', 'standard', 'branding-heading-link', 'article');</script>
+            </div><!-- close branding -->
+            <div class="story-meta">
+                <h6 class="kicker"><span class="kicker-label"><a href="https://www.nytimes.com/section/us">U.S.</a></span><span class="pipe">|</span>‘Not Our President’: Protests Spread After Donald Trump’s Election</h6>
+            </div><!-- close story-meta -->
+            <div class="user-tools">
+                <div id="Bar1" class="ad bar1-ad nocontent robots-nocontent"></div>
+                <div id="sharetools-masthead" aria-label="tools" role="group" class="sharetools theme-classic  sharetools-masthead  "
+                     data-shares="facebook,twitter,email,show-all,save"
+                     data-url="https://www.nytimes.com/2016/11/10/us/trump-election-protests.html"
+                     data-title="‘Not Our President’: Protests Spread After Donald Trump’s Election"
+                     data-author="By CHRISTOPHER MELE and ANNIE CORREAL"
+                     data-media="https://static01.nyt.com/images/2016/11/11/us/11attack2_xp/11attack2_xp-jumbo.jpg"
+                     data-description="Demonstrators marched through Manhattan toward Trump Tower, and similar protests took place in other cities and on college campuses across the country."
+                     data-publish-date="November 9, 2016"
+                >
+                    <div class="ad sharetools-inline-article-ad hidden nocontent robots-nocontent">
+                    </div>
+                </div><!-- close shareTools -->
+                <button class="button search-button"><i class="icon sprite-icon"></i><span class="button-text">Search</span></button>
+                <div class="user-tools-button-group button-group">
+                    <button class="button subscribe-button hidden" data-href="http://www.nytimes.com/subscriptions/Multiproduct/lp3004.html?campaignId=4XUYF">Subscribe Now</button>
+                    <button class="button login-button login-modal-trigger hidden">Log In</button>
+                    <button class="button notifications-button hidden"><i class="icon sprite-icon"></i><span class="button-text">0</span></button>
+                    <button class="button user-settings-button"><i class="icon sprite-icon"></i><span class="button-text">Settings</span></button>
+                </div><!-- close user-tools-button-group -->
+            </div><!-- close user-tools -->
+        </div><!-- close container -->
+        <div class="search-flyout-panel flyout-panel">
+            <button class="button close-button" type="button"><i class="icon"></i><span class="visually-hidden">Close search</span></button>
+            <nav class="search-form-control form-control layout-horizontal">
+                <h2 class="visually-hidden">Site Search Navigation</h2>
+                <form class="search-form" role="search">
+                    <div class="control">
+                        <div class="label-container visually-hidden">
+                            <label for="search-input">Search NYTimes.com</label>
+                        </div>
+                        <div class="field-container">
+                            <input id="search-input" name="search-input" type="text" class="search-input text" autocomplete="off" placeholder="Search NYTimes.com" />
+
+                            <button type="button" class="button clear-button" tabindex="-1" aria-describedby="clear-search-input"><i class="icon"></i><span id="clear-search-input" class="visually-hidden">Clear this text input</span></button>
+                            <div class="auto-suggest" style="display: none;">
+                                <ol></ol>
+                            </div>
+                            <button class="button submit-button" type="submit">Go</button>
+                        </div>
+                    </div><!-- close control -->
+                </form>
+            </nav>
+
+
+        </div><!-- close flyout-panel -->
+        <div id="notification-modals" class="notification-modals"></div>
+        <span class="story-short-url"><a href="https://nyti.ms/2elqdJq">https://nyti.ms/2elqdJq</a></span></header>
+    <nav id="ribbon" class="ribbon ribbon-start nocontent robots-nocontent" aria-hidden="true">
+        <div class="nocontent robots-nocontent">
+            <ol class="ribbon-menu">
+                <li class="collection ribbon-loader">
+                    <div class="loader loader-t-logo-32x32-ecedeb-ffffff"><span class="visually-hidden">Loading...</span></div>
+                </li>
+            </ol>
+            <div class="ribbon-navigation-container">
+                <nav class="ribbon-navigation next">
+                    <span class="visually-hidden">See next articles</span>
+                    <div class="arrow arrow-right">
+                        <div class="arrow-conceal"></div>
+                    </div>
+                </nav>
+                <nav class="ribbon-navigation previous">
+                    <span class="visually-hidden">See previous articles</span>
+                    <div class="arrow arrow-left">
+                        <div class="arrow-conceal"></div>
+                    </div>
+                </nav>
+            </div>
+        </div><!-- close nocontent -->
+    </nav>
+
+    <script type="text/javascript">
+        (function () {
+            var ribbon;
+            if (window.magnum.getFlags().indexOf('adAggro') !== -1 &&
+                (window.NYTD.Abra('www-story-pro-agro') !== 'control' &&
+                window.NYTD.Abra('www-story-pro-agro') !== null &&
+                window.NYTD.Abra('www-story-pro-agro') !== 'null' &&
+                window.NYTD.Abra('www-story-pro-agro') !== '')) {
+                ribbon = document.querySelector('#ribbon');
+                if (ribbon && ribbon.parentNode) {
+                    ribbon.parentNode.removeChild(ribbon);
+                }
+            }
+        })();
+    </script>
+    <nav id="navigation" class="navigation">
+        <h2 class="visually-hidden">Site Navigation</h2>
+    </nav><!-- close navigation -->
+
+    <nav id="mobile-navigation" class="mobile-navigation hidden">
+        <h2 class="visually-hidden">Site Mobile Navigation</h2>
+    </nav><!-- close mobile-navigation -->
+
+    <div id="navigation-edge" class="navigation-edge"></div>
+    <div id="page" class="page">
+        <div id="TopAd" class="ad top-ad nocontent robots-nocontent">
+            <div class="accessibility-ad-header visually-hidden">
+                <p>Advertisement</p>
+            </div>
+        </div>
+
+        <main id="main" class="main" role="main">
+            <article id="story" class="story theme-main   ">
+
+                <div id='TragedyAd' class='ad tragedy-ad nocontent robots-nocontent'></div>
+
+
+                <header id="story-header" class="story-header">
+                    <div id="story-meta" class="story-meta ">
+                        <div class="supported-by hidden nocontent robots-nocontent">
+                            <span class="ad-label">Supported by</span>
+                            <div id="supported-by-ad" class="supported-by-ad ad"></div>
+                        </div>
+                        <h3 class="kicker">
+                            <span class="kicker-label"><a href="https://www.nytimes.com/section/us">U.S.</a></span>                                                                                                                                            </h3>
+                        <h1 itemprop="headline" id="headline" class="headline">‘Not Our President’: Protests Spread After Donald Trump’s Election</h1>
+                        <div id="story-meta-footer" class="story-meta-footer">
+
+
+                            <p class="byline-dateline"><span class="byline" itemprop="author creator" itemscope itemtype="http://schema.org/Person"  itemid="https://www.nytimes.com/by/christopher-mele">By <a href="https://www.nytimes.com/by/christopher-mele" title="More Articles by CHRISTOPHER MELE"><span class="byline-author" data-byline-name="CHRISTOPHER MELE" itemprop="name">CHRISTOPHER MELE</span></a> and </span><span class="byline" itemprop="author creator" itemscope itemtype="http://schema.org/Person"  itemid="https://www.nytimes.com/by/annie-correal"><a href="https://www.nytimes.com/by/annie-correal" title="More Articles by ANNIE CORREAL"><span class="byline-author" data-byline-name="ANNIE CORREAL" itemprop="name" data-twitter-handle="anniecorreal">ANNIE CORREAL</span></a></span><time class="dateline" datetime="2017-02-28T08:02:06-05:00" itemprop="dateModified" content="2017-02-28T08:02:06-05:00">NOV. 9, 2016</time>
+                            </p>
+
+                            <div class="story-meta-footer-sharetools">
+                                <div id="sharetools-story-meta-footer" aria-label="tools" role="group" class="sharetools theme-classic  sharetools-story-meta-footer  "
+                                     data-shares="facebook,twitter,email,show-all,save"
+                                     data-url="https://www.nytimes.com/2016/11/10/us/trump-election-protests.html"
+                                     data-title="‘Not Our President’: Protests Spread After Donald Trump’s Election"
+                                     data-author="By CHRISTOPHER MELE and ANNIE CORREAL"
+                                     data-media="https://static01.nyt.com/images/2016/11/11/us/11attack2_xp/11attack2_xp-jumbo.jpg"
+                                     data-description="Demonstrators marched through Manhattan toward Trump Tower, and similar protests took place in other cities and on college campuses across the country."
+                                     data-publish-date="November 9, 2016"
+                                >
+                                    <a class="visually-hidden skip-to-text-link" href="#story-continues-1">Continue reading the main story</a>
+                                    <span class="sharetools-label visually-hidden">Share This Page</span>
+                                    <div class="ad sharetools-inline-article-ad hidden nocontent robots-nocontent">
+                                        <a class="visually-hidden skip-to-text-link" href="#story-continues-1">Continue reading the main story</a>
+                                    </div>
+                                </div><!-- close shareTools -->
+                            </div>
+                        </div><!-- close story-meta-footer -->
+                    </div><!-- close story-meta -->
+                </header>
+
+                <script type="text/javascript">
+                    if (
+                        window.magnum
+                        && window.magnum.getFlags().indexOf('headlineBalancer') > 0
+                        && window.magnum.headlineBalancer
+                        && window.magnum.headlineBalancer.initialize
+                        && window.magnum.headlineBalancer.shouldRun()
+                    ) {
+                        window.magnum.headlineBalancer.initialize();
+                    }
+                </script>
+
+
+                <div class="story-body-supplemental">
+                    <div class="story-body story-body-1">
+                        <figure class="promo media video lede layout-large-horizontal "
+                                data-videoid="100000004759928"
+                                data-media-action="modal"
+                                data-autoplay="false"
+                                data-embedded="false"
+                                data-adsensitivity=""
+                                data-live="false"
+                                aria-label="media" role="group">
+                            <span class="visually-hidden">Video</span>
+
+
+
+                            <figcaption class="caption">
+                                <h4 class="headline">Student Protests Break Out Nationwide</h4>
+
+                                <div class="caption-video">
+                                    <div class="summary-credit">
+                                        <p class="summary">Protests developed at high schools and colleges across the country after the election of Donald J. Trump.</p>
+                                        <span class="credit video-credit" itemprop="copyrightHolder">
+                    By ROBIN LINDSAY and MALACHY BROWNE on                                                                <span class="visually-hidden">Publish Date </span>November 9, 2016.
+                                    </span>
+                                        <span class="credit photo-credit" itemprop="copyrightHolder">
+                    Photo by Jim Wilson/The New York Times.
+                </span>
+                                        <a class="video-link" href= https://www.nytimes.com/video/us/100000004759928/student-protests-break-out-nationwide.html?action=click&amp;contentCollection=us&amp;module=lede&amp;region=caption&amp;pgtype=article >Watch in Times Video &#187;</a>
+                                    </div>
+
+                                    <div class="sharetools-video-container">
+                                        <div id="sharetools-video-tools-100000004759928"
+                                             class="sharetools sharetools-video-tools">
+                                            <ul>
+                                                <li class="sharetool embed-sharetool">
+                                                    <a href="javascript:;" data-share="embed" data-modal-title="">
+                                                        <i class="icon sprite-icon"></i>
+                                                        <span class="sharetool-text ">embed</span>
+                                                    </a>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                        <div id="sharetools-video-inline-100000004759928"
+                                             class="sharetools sharetools-video-inline"
+                                             data-shares="facebook|,twitter|"
+                                             data-url="https://www.nytimes.com/video/us/100000004759928/student-protests-break-out-nationwide.html?action=click&amp;contentCollection=us&amp;module=lede&amp;region=caption&amp;pgtype=article"
+                                             data-title="Student Protests Break Out Nationwide"
+                                             data-description="Protests developed at high schools and colleges across the country after the election of Donald J. Trump."
+                                             data-content-type="video">
+                                        </div>
+                                    </div>
+                                </div>
+                            </figcaption>
+                        </figure>
+                        <p class="story-body-text story-content" data-para-count="185" data-total-count="185">Thousands of people across the country marched, shut down highways, burned effigies and shouted angry slogans on Wednesday night to protest the election of <a href="http://www.nytimes.com/topic/person/donald-trump?inline=nyt-per" title="More articles about Donald J. Trump." class="meta-per">Donald J. Trump</a> as president.</p><p class="story-body-text story-content" data-para-count="157" data-total-count="342">The demonstrations, fueled by social media, continued into the early hours of Thursday. The crowds swelled as the night went on but remained mostly peaceful.</p><p class="story-body-text story-content" data-para-count="216" data-total-count="558">Protests were reported in cities as diverse as Dallas and Oakland and included marches in Boston; Chicago; Portland, Ore.; Seattle and Washington and at college campuses in California, Massachusetts and Pennsylvania.</p><p class="story-body-text story-content" data-para-count="392" data-total-count="950">In Oakland alone, the<a href="http://local.nixle.com/alert/5774587/"> Police Department said</a>, the crowd grew from about 3,000 people at 7 p.m. to 6,000 an hour later. The situation grew tense late Wednesday, <a href="http://www.sfgate.com/bayarea/article/Anti-Trump-protests-in-Oakland-turn-violent-10605621.php">with SFGate.com reporting</a> that a group of protesters had started small fires in the street and broken windows. Police officers in riot gear were called in, and at least one officer was injured, <a href="http://abc7news.com/news/fires-erupts-vandalism-reported-at-anti-trump-protest-in-oakland-/1599421/">according to other local news reports</a>.</p><figure class="media slideshow promo launch-media-viewer embedded layout-large-vertical" id="slideshow-100000004760946" data-media-action="modal" aria-label="media" role="group"
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 itemprop="associatedMedia" itemscope
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 itemid="https://static01.nyt.com/images/2016/11/11/us/11attack2_xp/11attack2_xp-blog427.jpg"
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 itemtype="http://schema.org/ImageObject"
+                    >
+                        <script type="application/json">
+                            {"url":"https:\/\/www.nytimes.com\/https:\/\/static01.nyt.com\/slideshow\/2016\/11\/11\/us\/the-anti-trump-protests-that-erupted-after-the-election.html","headline":"The Anti-Trump Protests That Erupted After the Election","summary":"The day after Donald J. Trump was voted into the White House, thousands marched, shut down highways, burned effigies and shouted angry slogans in protest.","content_kicker":"","section_name":"us","subsection_name":"","publication_date":1478795371,"id":100000004760946,"imageslideshow":{"intro":"","slides":[{"data_id":100000004760912,"slide_url":"11attack2_xp","image_type":"photo","caption":{"full":"<p>A pro-Trump supporter, right, clashed with an anti-Trump protester at Lee Circle in New Orleans on Wednesday after the man on the left grabbed a Trump flag from a truck.<\/p>","short":"A pro-Trump supporter, right, clashed with an anti-Trump protester at Lee Circle in New Orleans."},"credit":"Matthew Hinton\/The Advocate, via Associated Press.","image_crops":{"master768":{"height":887,"width":768,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-master768.jpg"},"videoSixteenByNine495":{"height":278,"width":495,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNine495.jpg"},"thumbWide":{"height":126,"width":190,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-thumbWide.jpg"},"largeHorizontalJumbo":{"height":682,"width":1024,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-largeHorizontalJumbo.jpg"},"articleLarge":{"height":693,"width":600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-articleLarge.jpg"},"hpLarge":{"height":287,"width":511,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-hpLarge.jpg"},"mediumThreeByTwo440":{"height":293,"width":440,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-mediumThreeByTwo440.jpg"},"largeHorizontal375":{"height":250,"width":375,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-largeHorizontal375.jpg"},"thumbLarge":{"height":150,"width":150,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-thumbLarge.jpg"},"mediumFlexible177":{"height":123,"width":177,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-mediumFlexible177.jpg"},"videoSixteenByNine540":{"height":304,"width":540,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNine540.jpg"},"square320":{"height":320,"width":320,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-square320.jpg"},"square640":{"height":640,"width":640,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-square640.jpg"},"moth":{"height":151,"width":151,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-moth.jpg"},"videoSmall":{"height":281,"width":500,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSmall.jpg"},"thumbStandard":{"height":75,"width":75,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-thumbStandard.jpg"},"videoSixteenByNine225":{"height":126,"width":225,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNine225.jpg"},"articleInline":{"height":132,"width":190,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-articleInline.jpg"},"smallSquare252":{"height":252,"width":252,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-smallSquare252.jpg"},"watch308":{"height":348,"width":312,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-watch308.jpg"},"hpSmall":{"height":113,"width":163,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-hpSmall.jpg"},"videoFifteenBySeven2610":{"height":1218,"width":2610,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoFifteenBySeven2610.jpg"},"slide":{"height":500,"width":433,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-slide.jpg"},"videoSixteenByNine96":{"height":54,"width":96,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNine96.jpg"},"master1050":{"height":1213,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-master1050.jpg"},"watch268":{"height":303,"width":272,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-watch268.jpg"},"master495":{"height":572,"width":495,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-master495.jpg"},"largeWidescreen573":{"height":322,"width":573,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-largeWidescreen573.jpg"},"sfSpan":{"height":263,"width":395,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-sfSpan.jpg"},"jumbo":{"height":1024,"width":887,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-jumbo.jpg"},"videoSixteenByNine150":{"height":84,"width":150,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNine150.jpg"},"videoSixteenByNine390":{"height":219,"width":390,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNine390.jpg"},"mediumSquare149":{"height":149,"width":149,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-mediumSquare149.jpg"},"largeWidescreen1050":{"height":590,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-largeWidescreen1050.jpg"},"videoSixteenByNine310":{"height":174,"width":310,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNine310.jpg"},"videoSixteenByNine1050":{"height":591,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNine1050.jpg"},"master180":{"height":208,"width":180,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-master180.jpg"},"smallSquare168":{"height":168,"width":168,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-smallSquare168.jpg"},"mediumThreeByTwo225":{"height":150,"width":225,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-mediumThreeByTwo225.jpg"},"verticalTwoByThree735":{"height":1102,"width":735,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-verticalTwoByThree735.jpg"},"facebookJumbo":{"height":549,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-facebookJumbo.jpg"},"filmstrip":{"height":190,"width":190,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-filmstrip.jpg"},"master315":{"height":364,"width":315,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-master315.jpg"},"miniMoth":{"height":70,"width":151,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-miniMoth.jpg"},"videoSixteenByNine480":{"height":270,"width":480,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNine480.jpg"},"master675":{"height":780,"width":675,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-master675.jpg"},"tmagArticle":{"height":684,"width":592,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-tmagArticle.jpg"},"videoSixteenByNine768":{"height":432,"width":768,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNine768.jpg"},"videoThumb":{"height":50,"width":75,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoThumb.jpg"},"videoSixteenByNine600":{"height":338,"width":600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNine600.jpg"},"videoSixteenByNine3000":{"height":1687,"width":3000,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNine3000.jpg"},"tmagSF":{"height":418,"width":362,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-tmagSF.jpg"},"videoSixteenByNineJumbo1600":{"height":900,"width":1600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoSixteenByNineJumbo1600.jpg"},"popup":{"height":500,"width":433,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-popup.jpg"},"mediumThreeByTwo252":{"height":168,"width":252,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-mediumThreeByTwo252.jpg"},"mediumThreeByTwo210":{"height":140,"width":210,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-mediumThreeByTwo210.jpg"},"windowsTile336H":{"height":336,"width":694,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-windowsTile336H.jpg"},"mediumThreeByTwo378":{"height":252,"width":378,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-mediumThreeByTwo378.jpg"},"videoFifteenBySeven1305":{"height":609,"width":1305,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoFifteenBySeven1305.jpg"},"superJumbo":{"height":2048,"width":1773,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-superJumbo.jpg"},"videoLarge":{"height":507,"width":768,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack2_xp\/11attack2_xp-videoLarge.jpg"}},"url":null,"short_url":null,"approved_for_syndication":true},{"data_id":100000004760917,"slide_url":"11attack3_xp","image_type":"photo","caption":{"full":"<p>Elizabeth Bushnell, who said she is Muslim, is embraced by Conner Crenshaw, left, and Jamal Edwards during an anti-Trump protest at Lee Circle in New Orleans on Wednesday.<\/p>","short":"Elizabeth Bushnell, who said she is Muslim, is embraced during an protest in New Orleans."},"credit":"Matthew Hinton\/The Advocate, via Associated Press.","image_crops":{"master768":{"height":418,"width":768,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-master768.jpg"},"videoSixteenByNine495":{"height":278,"width":495,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNine495.jpg"},"thumbWide":{"height":126,"width":190,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-thumbWide.jpg"},"largeHorizontalJumbo":{"height":682,"width":1024,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-largeHorizontalJumbo.jpg"},"articleLarge":{"height":327,"width":600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-articleLarge.jpg"},"hpLarge":{"height":287,"width":511,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-hpLarge.jpg"},"mediumThreeByTwo440":{"height":293,"width":440,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-mediumThreeByTwo440.jpg"},"largeHorizontal375":{"height":250,"width":375,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-largeHorizontal375.jpg"},"thumbLarge":{"height":150,"width":150,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-thumbLarge.jpg"},"mediumFlexible177":{"height":125,"width":177,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-mediumFlexible177.jpg"},"videoSixteenByNine540":{"height":304,"width":540,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNine540.jpg"},"square320":{"height":320,"width":320,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-square320.jpg"},"square640":{"height":640,"width":640,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-square640.jpg"},"moth":{"height":151,"width":151,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-moth.jpg"},"videoSmall":{"height":281,"width":500,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSmall.jpg"},"thumbStandard":{"height":75,"width":75,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-thumbStandard.jpg"},"videoSixteenByNine225":{"height":126,"width":225,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNine225.jpg"},"articleInline":{"height":135,"width":190,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-articleInline.jpg"},"smallSquare252":{"height":252,"width":252,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-smallSquare252.jpg"},"watch308":{"height":348,"width":312,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-watch308.jpg"},"hpSmall":{"height":115,"width":163,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-hpSmall.jpg"},"videoFifteenBySeven2610":{"height":1218,"width":2610,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoFifteenBySeven2610.jpg"},"slide":{"height":327,"width":600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-slide.jpg"},"videoSixteenByNine96":{"height":54,"width":96,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNine96.jpg"},"master1050":{"height":571,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-master1050.jpg"},"watch268":{"height":303,"width":272,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-watch268.jpg"},"master495":{"height":269,"width":495,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-master495.jpg"},"largeWidescreen573":{"height":322,"width":573,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-largeWidescreen573.jpg"},"sfSpan":{"height":263,"width":395,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-sfSpan.jpg"},"jumbo":{"height":557,"width":1024,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-jumbo.jpg"},"videoSixteenByNine150":{"height":84,"width":150,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNine150.jpg"},"videoSixteenByNine390":{"height":219,"width":390,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNine390.jpg"},"mediumSquare149":{"height":149,"width":149,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-mediumSquare149.jpg"},"largeWidescreen1050":{"height":590,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-largeWidescreen1050.jpg"},"videoSixteenByNine310":{"height":174,"width":310,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNine310.jpg"},"videoSixteenByNine1050":{"height":591,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNine1050.jpg"},"master180":{"height":98,"width":180,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-master180.jpg"},"smallSquare168":{"height":168,"width":168,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-smallSquare168.jpg"},"mediumThreeByTwo225":{"height":150,"width":225,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-mediumThreeByTwo225.jpg"},"verticalTwoByThree735":{"height":1102,"width":735,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-verticalTwoByThree735.jpg"},"facebookJumbo":{"height":549,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-facebookJumbo.jpg"},"filmstrip":{"height":190,"width":190,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-filmstrip.jpg"},"master315":{"height":171,"width":315,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-master315.jpg"},"miniMoth":{"height":70,"width":151,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-miniMoth.jpg"},"videoSixteenByNine480":{"height":270,"width":480,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNine480.jpg"},"master675":{"height":367,"width":675,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-master675.jpg"},"tmagArticle":{"height":322,"width":592,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-tmagArticle.jpg"},"videoSixteenByNine768":{"height":432,"width":768,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNine768.jpg"},"videoThumb":{"height":50,"width":75,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoThumb.jpg"},"videoSixteenByNine600":{"height":338,"width":600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNine600.jpg"},"videoSixteenByNine3000":{"height":1686,"width":3000,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNine3000.jpg"},"tmagSF":{"height":197,"width":362,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-tmagSF.jpg"},"videoSixteenByNineJumbo1600":{"height":899,"width":1600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoSixteenByNineJumbo1600.jpg"},"popup":{"height":354,"width":650,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-popup.jpg"},"mediumThreeByTwo252":{"height":168,"width":252,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-mediumThreeByTwo252.jpg"},"mediumThreeByTwo210":{"height":140,"width":210,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-mediumThreeByTwo210.jpg"},"windowsTile336H":{"height":336,"width":694,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-windowsTile336H.jpg"},"mediumThreeByTwo378":{"height":252,"width":378,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-mediumThreeByTwo378.jpg"},"videoFifteenBySeven1305":{"height":609,"width":1305,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoFifteenBySeven1305.jpg"},"superJumbo":{"height":1115,"width":2048,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-superJumbo.jpg"},"videoLarge":{"height":507,"width":768,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11attack3_xp\/11attack3_xp-videoLarge.jpg"}},"url":null,"short_url":null,"approved_for_syndication":true},{"data_id":100000004760794,"slide_url":"11protests_xp","image_type":"photo","caption":{"full":"<p>The police clashed with demonstrators blocking traffic on the 101 Freeway through downtown Los Angeles on Wednesday.<\/p>","short":"The police clashed with demonstrators blocking traffic on the 101 Freeway through Los Angeles."},"credit":"Ringo Chiu\/Agence France-Presse \u2014 Getty Images","image_crops":{"master768":{"height":526,"width":768,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-master768.jpg"},"videoSixteenByNine495":{"height":278,"width":495,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNine495.jpg"},"thumbWide":{"height":126,"width":190,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-thumbWide.jpg"},"largeHorizontalJumbo":{"height":683,"width":1024,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-largeHorizontalJumbo.jpg"},"articleLarge":{"height":411,"width":600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-articleLarge.jpg"},"hpLarge":{"height":287,"width":511,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-hpLarge.jpg"},"mediumThreeByTwo440":{"height":293,"width":440,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-mediumThreeByTwo440.jpg"},"largeHorizontal375":{"height":250,"width":375,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-largeHorizontal375.jpg"},"thumbLarge":{"height":150,"width":150,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-thumbLarge.jpg"},"mediumFlexible177":{"height":129,"width":177,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-mediumFlexible177.jpg"},"videoSixteenByNine540":{"height":304,"width":540,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNine540.jpg"},"square320":{"height":320,"width":320,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-square320.jpg"},"square640":{"height":640,"width":640,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-square640.jpg"},"moth":{"height":151,"width":151,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-moth.jpg"},"videoSmall":{"height":281,"width":500,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSmall.jpg"},"thumbStandard":{"height":75,"width":75,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-thumbStandard.jpg"},"videoSixteenByNine225":{"height":126,"width":225,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNine225.jpg"},"articleInline":{"height":138,"width":190,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-articleInline.jpg"},"smallSquare252":{"height":252,"width":252,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-smallSquare252.jpg"},"watch308":{"height":348,"width":312,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-watch308.jpg"},"hpSmall":{"height":118,"width":163,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-hpSmall.jpg"},"videoFifteenBySeven2610":{"height":1218,"width":2610,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoFifteenBySeven2610.jpg"},"slide":{"height":411,"width":600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-slide.jpg"},"videoSixteenByNine96":{"height":54,"width":96,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNine96.jpg"},"master1050":{"height":719,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-master1050.jpg"},"watch268":{"height":303,"width":272,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-watch268.jpg"},"master495":{"height":339,"width":495,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-master495.jpg"},"largeWidescreen573":{"height":322,"width":573,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-largeWidescreen573.jpg"},"sfSpan":{"height":263,"width":395,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-sfSpan.jpg"},"jumbo":{"height":701,"width":1024,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-jumbo.jpg"},"videoSixteenByNine150":{"height":84,"width":150,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNine150.jpg"},"videoSixteenByNine390":{"height":219,"width":390,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNine390.jpg"},"mediumSquare149":{"height":149,"width":149,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-mediumSquare149.jpg"},"largeWidescreen1050":{"height":591,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-largeWidescreen1050.jpg"},"videoSixteenByNine310":{"height":174,"width":310,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNine310.jpg"},"videoSixteenByNine1050":{"height":591,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNine1050.jpg"},"master180":{"height":123,"width":180,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-master180.jpg"},"smallSquare168":{"height":168,"width":168,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-smallSquare168.jpg"},"mediumThreeByTwo225":{"height":150,"width":225,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-mediumThreeByTwo225.jpg"},"verticalTwoByThree735":{"height":1103,"width":735,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-verticalTwoByThree735.jpg"},"facebookJumbo":{"height":550,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-facebookJumbo.jpg"},"filmstrip":{"height":190,"width":190,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-filmstrip.jpg"},"master315":{"height":216,"width":315,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-master315.jpg"},"miniMoth":{"height":70,"width":151,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-miniMoth.jpg"},"videoSixteenByNine480":{"height":270,"width":480,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNine480.jpg"},"master675":{"height":462,"width":675,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-master675.jpg"},"tmagArticle":{"height":405,"width":592,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-tmagArticle.jpg"},"videoSixteenByNine768":{"height":432,"width":768,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNine768.jpg"},"videoThumb":{"height":50,"width":75,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoThumb.jpg"},"videoSixteenByNine600":{"height":338,"width":600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNine600.jpg"},"videoSixteenByNine3000":{"height":1688,"width":3000,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNine3000.jpg"},"tmagSF":{"height":248,"width":362,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-tmagSF.jpg"},"videoSixteenByNineJumbo1600":{"height":900,"width":1600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoSixteenByNineJumbo1600.jpg"},"popup":{"height":445,"width":650,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-popup.jpg"},"mediumThreeByTwo252":{"height":168,"width":252,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-mediumThreeByTwo252.jpg"},"mediumThreeByTwo210":{"height":140,"width":210,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-mediumThreeByTwo210.jpg"},"windowsTile336H":{"height":336,"width":694,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-windowsTile336H.jpg"},"mediumThreeByTwo378":{"height":252,"width":378,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-mediumThreeByTwo378.jpg"},"videoFifteenBySeven1305":{"height":609,"width":1305,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoFifteenBySeven1305.jpg"},"superJumbo":{"height":1403,"width":2048,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-superJumbo.jpg"},"videoLarge":{"height":507,"width":768,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/11\/us\/11protests_xp\/11protests_xp-videoLarge.jpg"}},"url":null,"short_url":null,"approved_for_syndication":true},{"data_id":100000004760926,"slide_url":"elex-protests","image_type":"photo","caption":{"full":"<p>An anti-Trump protest at Columbus Circle in Manhattan on Wednesday.<\/p>","short":"An anti-Trump protest at Columbus Circle in Manhattan on Wednesday."},"credit":"Hiroko Masuike\/The New York Times","image_crops":{"videoSixteenByNine495":{"height":278,"width":495,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNine495.jpg"},"master768":{"height":512,"width":768,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-master768.jpg"},"thumbWide":{"height":126,"width":190,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-thumbWide.jpg"},"largeHorizontalJumbo":{"height":683,"width":1024,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-largeHorizontalJumbo.jpg"},"articleLarge":{"height":400,"width":600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-articleLarge.jpg"},"hpLarge":{"height":287,"width":511,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-hpLarge.jpg"},"mediumThreeByTwo440":{"height":293,"width":440,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-mediumThreeByTwo440.jpg"},"largeHorizontal375":{"height":250,"width":375,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-largeHorizontal375.jpg"},"thumbLarge":{"height":150,"width":150,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-thumbLarge.jpg"},"mediumFlexible177":{"height":118,"width":177,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-mediumFlexible177.jpg"},"videoSixteenByNine540":{"height":304,"width":540,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNine540.jpg"},"square320":{"height":320,"width":320,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-square320.jpg"},"square640":{"height":640,"width":640,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-square640.jpg"},"moth":{"height":151,"width":151,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-moth.jpg"},"videoSmall":{"height":281,"width":500,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSmall.jpg"},"thumbStandard":{"height":75,"width":75,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-thumbStandard.jpg"},"videoSixteenByNine225":{"height":126,"width":225,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNine225.jpg"},"articleInline":{"height":127,"width":190,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-articleInline.jpg"},"smallSquare252":{"height":252,"width":252,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-smallSquare252.jpg"},"watch308":{"height":348,"width":312,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-watch308.jpg"},"hpSmall":{"height":109,"width":163,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-hpSmall.jpg"},"videoFifteenBySeven2610":{"height":1218,"width":2610,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoFifteenBySeven2610.jpg"},"slide":{"height":400,"width":600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-slide.jpg"},"videoSixteenByNine96":{"height":54,"width":96,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNine96.jpg"},"master1050":{"height":700,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-master1050.jpg"},"watch268":{"height":303,"width":272,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-watch268.jpg"},"master495":{"height":330,"width":495,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-master495.jpg"},"largeWidescreen573":{"height":322,"width":573,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-largeWidescreen573.jpg"},"sfSpan":{"height":263,"width":395,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-sfSpan.jpg"},"jumbo":{"height":683,"width":1024,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-jumbo.jpg"},"videoSixteenByNine150":{"height":84,"width":150,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNine150.jpg"},"videoSixteenByNine390":{"height":219,"width":390,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNine390.jpg"},"mediumSquare149":{"height":149,"width":149,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-mediumSquare149.jpg"},"largeWidescreen1050":{"height":591,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-largeWidescreen1050.jpg"},"videoSixteenByNine310":{"height":174,"width":310,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNine310.jpg"},"videoSixteenByNine1050":{"height":591,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNine1050.jpg"},"master180":{"height":120,"width":180,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-master180.jpg"},"smallSquare168":{"height":168,"width":168,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-smallSquare168.jpg"},"mediumThreeByTwo225":{"height":150,"width":225,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-mediumThreeByTwo225.jpg"},"verticalTwoByThree735":{"height":1103,"width":735,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-verticalTwoByThree735.jpg"},"facebookJumbo":{"height":550,"width":1050,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-facebookJumbo.jpg"},"filmstrip":{"height":190,"width":190,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-filmstrip.jpg"},"miniMoth":{"height":70,"width":151,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-miniMoth.jpg"},"master315":{"height":210,"width":315,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-master315.jpg"},"videoSixteenByNine480":{"height":270,"width":480,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNine480.jpg"},"master675":{"height":450,"width":675,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-master675.jpg"},"tmagArticle":{"height":395,"width":592,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-tmagArticle.jpg"},"videoSixteenByNine768":{"height":432,"width":768,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNine768.jpg"},"videoThumb":{"height":50,"width":75,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoThumb.jpg"},"videoSixteenByNine600":{"height":338,"width":600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNine600.jpg"},"videoSixteenByNine3000":{"height":1688,"width":3000,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNine3000.jpg"},"tmagSF":{"height":241,"width":362,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-tmagSF.jpg"},"videoSixteenByNineJumbo1600":{"height":900,"width":1600,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoSixteenByNineJumbo1600.jpg"},"popup":{"height":433,"width":650,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-popup.jpg"},"mediumThreeByTwo252":{"height":168,"width":252,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-mediumThreeByTwo252.jpg"},"mediumThreeByTwo210":{"height":140,"width":210,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-mediumThreeByTwo210.jpg"},"windowsTile336H":{"height":336,"width":694,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-windowsTile336H.jpg"},"mediumThreeByTwo378":{"height":252,"width":378,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-mediumThreeByTwo378.jpg"},"videoFifteenBySeven1305":{"height":609,"width":1305,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoFifteenBySeven1305.jpg"},"superJumbo":{"height":1365,"width":2048,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-superJumbo.jpg"},"videoLarge":{"height":507,"width":768,"url":"https:\/\/static01.nyt.com\/images\/2016\/11\/10\/us\/elections\/elex-protests\/10elex-protests2-video-videoLarge.jpg"}},"url":null,"short_url":null,"approved_for_syndication":true}]},"related_assets":[]}    </script>
+                        <span class="visually-hidden">Slide Show</span>
+                        <div class="image">
+                            <img src="https://static01.nyt.com/images/2016/11/11/us/11attack2_xp/11attack2_xp-blog427.jpg" itemprop="url" itemid="https://static01.nyt.com/images/2016/11/11/us/11attack2_xp/11attack2_xp-blog427.jpg"/>
+
+                            <div class="media-action-overlay">
+                                <i class="icon sprite-icon"></i>
+                                <div class="media-meta">
+                                    <h5 class="kicker"><span class="kicker-label">Slide Show</span><span class="pipe">|</span><span class="counter">4 Photos</span></h5>
+                                    <h4 class="headline">The Anti-Trump Protests That Erupted After the Election</h4>
+                                </div>
+                            </div><!-- close media-action-overlay -->
+
+                        </div><!-- close image -->
+
+                        <figcaption class="caption" itemprop="description">
+                            <h4 class="headline">The Anti-Trump Protests That Erupted After the Election</h4>
+                            <p class="credit" itemprop="copyrightHolder">
+                                <span class="visually-hidden">Credit</span>Matthew Hinton/The Advocate, via Associated Press.        </p>
+                        </figcaption>
+
+                        <meta itemprop="identifier" content="https://static01.nyt.com/images/2016/11/11/us/11attack2_xp/11attack2_xp-blog427.jpg" />
+                        <meta itemprop="height" content="493" />
+                        <meta itemprop="width" content="427" />
+
+                    </figure>
+                        <p class="story-body-text story-content" data-para-count="191" data-total-count="1141">It was the <a href="http://www.nytimes.com/2016/11/10/us/trump-election-protest-berkeley-oakland.html">second night of protests</a> there, following unruly demonstrations that led to <a href="http://abc7news.com/news/thousands-take-to-streets-of-oakland-in-protest-of-election-results/1599421/">property damage and left at least one </a>person injured shortly after Mr. Trump’s election was announced.</p>        <a class="visually-hidden skip-to-text-link" href="#story-continues-1">Continue reading the main story</a>
+                    </div><!-- close story-body -->
+                    <div class="supplemental first" id="supplemental-1">
+                    </div><!-- close supplemental -->
+                </div><!-- close story-body-supplemental -->
+                <div class="story-interrupter" id="story-continues-1">
+                    <div id="FlexAd" class="ad flex-ad nocontent robots-nocontent">
+                        <div class="accessibility-ad-header visually-hidden">
+                            <p>Advertisement</p>
+                        </div>
+                        <a class="visually-hidden skip-to-text-link" href="#story-continues-2">Continue reading the main story</a>
+                        <div class="flex-ad-creative"></div>
+                    </div>
+                </div>
+                <div class="story-body-supplemental">
+                    <div class="story-body story-body-2">
+                        <p class="story-body-text story-content" data-para-count="149" data-total-count="1290" id="story-continues-2">The protests on Wednesday came just hours after Hillary Clinton, in <a href="http://www.nytimes.com/2016/11/09/us/politics/donald-trump-won-now-what.html">her concession speech</a>, asked supporters to give Mr. Trump a “chance to lead.”</p><div id="story-ad-1" class="story-ad ad ad-placeholder nocontent robots-nocontent ">
+                        <div class="accessibility-ad-header visually-hidden">
+                            <p>Advertisement</p>
+                        </div>
+                        <a class="visually-hidden skip-to-text-link" href="#story-continues-3">Continue reading the main story</a>
+                    </div>
+                        <p class="story-body-text story-content" data-para-count="264" data-total-count="1554" id="story-continues-3">One of the <a href="http://www.latimes.com/local/lanow/la-me-ln-downtown-la-trump-protests-20161109-htmlstory.html">biggest demonstrations was in Los Angeles</a>, where protesters burned a Trump effigy at City Hall and shut down a section of Highway 101. Law enforcement officials were called out to disperse the hundreds of people who swarmed across the multilane freeway.</p><p class="story-body-text story-content" data-para-count="131" data-total-count="1685">In New York, crowds converged at Trump Tower, on Fifth Avenue at 56th Street in Midtown Manhattan, where the president-elect lives.</p><div id="story-ad--aggro-4" class="story-ad ad ad-placeholder nocontent robots-nocontent  ad-aggro-4 aggro-only">
+                        <div class="accessibility-ad-header visually-hidden">
+                            <p>Advertisement</p>
+                        </div>
+                        <a class="visually-hidden skip-to-text-link" href="#story-continues-4">Continue reading the main story</a>
+                    </div>
+                        <p class="story-body-text story-content" data-para-count="227" data-total-count="1912" id="story-continues-4">They chanted “Not our president” and “New York hates Trump” and carried signs that said, among other things, “Dump Trump.” Restaurant workers in their uniforms briefly left their posts to cheer on the demonstrators.</p><p class="story-body-text story-content" data-para-count="204" data-total-count="2116">The demonstrations forced streets to be closed, snarled traffic and drew a large police presence. They started in separate waves from Union Square and Columbus Circle and snaked their way through Midtown.</p><div id="story-ad--aggro-6" class="story-ad ad ad-placeholder nocontent robots-nocontent  ad-aggro-6 aggro-only">
+                        <div class="accessibility-ad-header visually-hidden">
+                            <p>Advertisement</p>
+                        </div>
+                        <a class="visually-hidden skip-to-text-link" href="#story-continues-5">Continue reading the main story</a>
+                    </div>
+                        <p class="story-body-text story-content" data-para-count="97" data-total-count="2213" id="story-continues-5">Loaded dump trucks lined Fifth Avenue for two blocks outside Trump Tower as a form of protection.</p><p class="story-body-text story-content" data-para-count="145" data-total-count="2358">Emanuel Perez, 25, of the Bronx, who works at a restaurant in Manhattan and grew up in Guerrero, Mexico, was among the many Latinos in the crowd.</p><p class="story-body-text story-content" data-para-count="328" data-total-count="2686">“I came here because people came out to protest the racism that he’s promoting,” he said in Spanish, referring to Mr. Trump. “I’m not scared for myself personally. What I’m worried about is how many children are going to be separated from their families. It will not be just one. It will be thousands of families.”</p><div id="story-ad--aggro-8" class="story-ad ad ad-placeholder nocontent robots-nocontent  ad-aggro-4 ad-aggro-8 aggro-only">
+                        <div class="accessibility-ad-header visually-hidden">
+                            <p>Advertisement</p>
+                        </div>
+                        <a class="visually-hidden skip-to-text-link" href="#story-continues-6">Continue reading the main story</a>
+                    </div>
+                        <p class="story-body-text story-content" data-para-count="102" data-total-count="2788" id="story-continues-6">Protesters with umbrellas beat a piñata of Mr. Trump, which quickly lost a leg, outside the building.</p><div class="newsletter-signup hidden auto-newsletter" id="newsletter-promo" data-newsletter-productCode="" data-newsletter-productTitle="">
+                        <script type="application/json" id="auto-newsletter-rules">[{"headline":"California Today","summary":"The news and stories that matter to Californians (and anyone else interested in the state), delivered weekday mornings.","product-code":"CA","product-title":"California Today","sample-url":"http:\/\/www.nytimes.com\/newsletters\/sample\/california-today?pgtype=subscriptionspage&version=new&contentId=CA&eventName=sample&module=newsletter-sign-up"},{"headline":"Race\/Related Newsletter","summary":"Join a deep and provocative exploration of race with New York Times journalists.","product-code":"RR","product-title":"Race Related","sample-url":"http:\/\/www.nytimes.com\/newsletters\/sample\/race-related?pgtype=subscriptionspage&version=new&contentId=RR&eventName=sample&module=newsletter-sign-up"},{"headline":"The Interpreter Newsletter","summary":"Understand the world with sharp insight and commentary on the major news stories of the week.","product-code":"INT","product-title":"The Interpreter"}]</script>
+                        <h2 class="headline"></h2>    <p class="summary"></p>    <form name="regilite" class="newsletter-form" method="post" autocomplete="off">
+                        <div class="control input-control">
+                            <div class="form-errors">
+                                <p class="error captcha-error hidden">Please verify you're not a robot by clicking the box.</p>
+                                <p class="error invalid-email-error hidden">Invalid email address. Please re-enter.</p>
+                                <p class="error buffet-error hidden">You must select a newsletter to subscribe to.</p>
+                            </div>
+                            <div class="field-container">
+                                <input id="email" name="email" class="email-input" type="email" aria-required="true" placeholder="Enter your email address" value="">
+                                <button id="submit-button" type="submit" class="button submit-button">Sign Up</button>
+                            </div>
+                        </div><!-- close control -->
+                        <div class="control checkbox-control">
+                            <div class="field-container">
+                                <input id="special-offers" class="checkbox" type="checkbox" name="special-offers" value="MM" checked="">
+                            </div>
+                            <div class="label-container">
+                                <label class="checkboxLabel" for="special-offers">Receive occasional updates and special offers for The New York Times's products and services.</label>
+                            </div>
+                        </div><!-- close control -->
+                        <div class="g-recaptcha" id="captcha-container" data-sitekey="6LeN0R4TAAAAACwPa5WX2QYE0npOf2-2veTOm2Tp"></div>
+                    </form>
+                        <div class="messages">
+                            <h2 class="success-message hidden">Thank you for subscribing.</h2>
+                            <h2 class="error submit-error hidden">An error has occurred. Please try again later.</h2>
+                            <h2 class="subscriber hidden">You are already subscribed to this email.</h2>
+                            <p class="view-all-link hidden"><a href="/newsletters" target="_blank">View all New York Times newsletters.</a></p>
+                        </div><!-- close messages -->
+                        <ul class="footer">
+                            <li id="sample-newsletter-link" class="sample"><a href="" target="_blank">See Sample</a></li>
+                            <li class="manage-email"><a href="/mem/email.html" target="_blank">Manage Email Preferences</a></li>
+                            <li class="logout hidden"><a href="/logout" target="_blank">Not you?</a></li>
+                            <li class="privacy"><a href="/privacy" target="_blank">Privacy Policy</a></li>
+                        </ul><!-- close footer -->
+                        <script src="https://www.google.com/recaptcha/api.js" async="async" defer="defer"></script>
+                    </div>
+                        <p class="story-body-text story-content" data-para-count="83" data-total-count="2871">The Police Department said on Wednesday night that 15 protesters had been arrested.</p><p class="story-body-text story-content" data-para-count="119" data-total-count="2990">Bianca Rivera, 25, of East Harlem, described Mr. Trump’s election as something that was “not supposed to happen.”</p><p class="story-body-text story-content" data-para-count="155" data-total-count="3145">“We’re living in a country that’s supposed to be united, a melting pot,” she said. “It’s exposing all these underground racists and sexists.”</p><div id="story-ad-2" class="story-ad ad ad-placeholder nocontent robots-nocontent  ad-aggro-10">
+                        <div class="accessibility-ad-header visually-hidden">
+                            <p>Advertisement</p>
+                        </div>
+                        <a class="visually-hidden skip-to-text-link" href="#story-continues-7">Continue reading the main story</a>
+                    </div>
+                        <p class="story-body-text story-content" data-para-count="151" data-total-count="3296" id="story-continues-7">Elsewhere in the country, college students gathered in spontaneous marches and asked university leaders to schedule meetings to reflect on the results.</p><p class="story-body-text story-content" data-para-count="175" data-total-count="3471">After <a href="http://www.nytimes.com/2016/11/10/us/politics/trump-speech-transcript.html">Mr. Trump’s victory speech</a>, more than 2,000 students at the University of California, Los Angeles, marched through the streets of the campus’s Westwood neighborhood.</p><div id="story-ad--aggro-12" class="story-ad ad ad-placeholder nocontent robots-nocontent  ad-aggro-4 ad-aggro-6 aggro-only">
+                        <div class="accessibility-ad-header visually-hidden">
+                            <p>Advertisement</p>
+                        </div>
+                        <a class="visually-hidden skip-to-text-link" href="#story-continues-8">Continue reading the main story</a>
+                    </div>
+                        <p class="story-body-text story-content" data-para-count="234" data-total-count="3705" id="story-continues-8">There were similar protests at the University of Southern California, in Los Angeles; University of California campuses in Berkeley, San Diego and Santa Barbara; Temple University, in Philadelphia; and the University of Massachusetts.</p><figure class="media twitter embedded layout-horizontal-inset">
+                        <blockquote class="twitter-tweet">
+                            <p itemprop="articleBody">
+                                Large crowd of anti-Trump protesters outside of Trump Tower in NYC! <a href="https://twitter.com/hashtag/AntiFa?src=hash">#AntiFa</a> <a href="https://t.co/jwQau88DiW">pic.twitter.com/jwQau88DiW</a>        </p> —
+                            Ash J (@AshAgony)
+                            <a href="https://twitter.com/AshAgony/status/796517436002549760">Nov. 10, 2016</a>
+                        </blockquote>
+                        <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+                    </figure>
+                        <p class="story-body-text story-content" data-para-count="77" data-total-count="3782">High school students also walked out of classes in protest in several cities.</p><p class="story-body-text story-content" data-para-count="152" data-total-count="3934">As U.C.L.A. students made their way to classes on Wednesday, they talked about how to make sense of an outcome that had seemed impossible a day earlier.</p><p class="story-body-text story-content" data-para-count="252" data-total-count="4186">“I’m more than a little nervous about the future,” said Blanca Torres, a sophomore anthropology major. “We all want to have conversations with each other, to figure out how to move forward. There’s a whole new reality out there for us now.”</p><p class="story-body-text story-content" data-para-count="99" data-total-count="4285">Chuy Fernandez, a fifth-year economics student, said he was eager to air his unease with his peers.</p><p class="story-body-text story-content" data-para-count="173" data-total-count="4458">“I’m feeling sad with this huge sense of uncertainty,” Mr. Fernandez said. The son of a Mexican immigrant, he said it was difficult not to take the outcome personally.</p><figure class="media twitter embedded layout-horizontal-inset">
+                        <blockquote class="twitter-tweet">
+                            <p itemprop="articleBody">
+                                Flag burning on 5th Avenue in front of Trump Tower right now. <a href="https://t.co/1LAGHCNjxL">pic.twitter.com/1LAGHCNjxL</a>        </p> —
+                            Patrick deHahn (@patrickdehahn)
+                            <a href="https://twitter.com/patrickdehahn/status/796521221680746496">Nov. 10, 2016</a>
+                        </blockquote>
+                        <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+                    </figure>
+                        <div id="story-ad--aggro-16" class="story-ad ad ad-placeholder nocontent robots-nocontent  ad-aggro-4 ad-aggro-8 aggro-only">
+                            <div class="accessibility-ad-header visually-hidden">
+                                <p>Advertisement</p>
+                            </div>
+                            <a class="visually-hidden skip-to-text-link" href="#story-continues-9">Continue reading the main story</a>
+                        </div>
+                        <p class="story-body-text story-content" data-para-count="202" data-total-count="4660" id="story-continues-9">“We’re all just kind of waiting for a ticking time bomb, like looking around and thinking who will be deported,” he said. “That’s the exact opposite of what most of us thought would happen.”</p><p class="story-body-text story-content" data-para-count="138" data-total-count="4798">On Facebook, a page titled “Not My President” <a href="https://www.facebook.com/events/1143506425717593/">called for protesters</a> to gather on Inauguration Day, Jan. 20, in the nation’s capital.</p><p class="story-body-text story-content" data-para-count="175" data-total-count="4973">“We refuse to recognize Donald Trump as the president of the United States, and refuse to take orders from a government that puts bigots into power,” the organizers wrote.</p><div id="story-ad-3" class="story-ad ad ad-placeholder nocontent robots-nocontent  ad-aggro-6">
+                        <div class="accessibility-ad-header visually-hidden">
+                            <p>Advertisement</p>
+                        </div>
+                        <a class="visually-hidden skip-to-text-link" href="#story-continues-10">Continue reading the main story</a>
+                    </div>
+                        <p class="story-body-text story-content" data-para-count="133" data-total-count="5106" id="story-continues-10">“We have to make it clear to the public that we did not choose this man for office and that we won’t stand for his ideologies.”</p><footer class="story-footer story-content">
+                        <div class="story-meta">
+                            <div class="story-notes"><p>Jennifer Medina and Stephanie Saul contributed reporting.</p></div>
+
+
+                            <p class="story-print-citation">A version of this article appears in print on November 10, 2016, on Page P12 of the <span itemprop="printEdition">New York edition</span> with the headline: ‘Not Our President’: Protests Spread. <span class="story-footer-links">  <span><a href="http://www.nytreprints.com/" target="_blank">Order Reprints</a><span class="pipe">|</span></span>  <span><a href="http://www.nytimes.com/pages/todayspaper/index.html" target="_blank">Today's Paper</a><span class="pipe">|</span></span><span><a href="http://www.nytimes.com/subscriptions/Multiproduct/lp839RF.html?campaignId=48JQY" target="_blank">Subscribe</a></span>
+</span>
+                            </p>
+
+                        </div><!-- close story-meta -->
+                    </footer>
+                        <a class="visually-hidden skip-to-text-link" href="#whats-next">Continue reading the main story</a>
+                    </div><!-- close story-body -->
+                    <div class="supplemental " id="supplemental-2">
+                    </div><!-- close supplemental -->
+                </div><!-- close story-body-supplemental -->
+
+
+                <div class="reader-satisfaction-survey prompt feedback-prompt story-content hidden">
+                    <a class="feedback-link" href="https://docs.google.com/forms/d/e/1FAIpQLSfLW30xgZodF1qRAg80oWEGuDpW-1HHaL0g42G3SmvB2f4lCw/viewform?entry.8537735=https://www.nytimes.com/2016/11/10/us/trump-election-protests.html" target="_blank">
+                        <p class="feedback-message">We&#8217;re interested in your feedback on this page. <strong>Tell us what you think.</strong></p>
+                    </a>
+                </div>
+
+                <div id="storage-drawer" class="hidden">
+                    <div class="supplemental-sub-item" data-attribute-position="0" data-attribute-name="CombinedMarginalia" data-attribute-type="Related" data-attribute-subtype="">
+                        <aside class="marginalia related-combined-coverage-marginalia marginalia-item nocontent robots-nocontent" data-marginalia-type="sprinkled" role="complementary" module="Related-CombinedMarginalia">
+                            <div class="nocontent robots-nocontent">
+                                <header>
+                                    <h2 class="module-heading">Related Coverage</h2>
+                                </header>
+                                <ul>
+                                    <li><article class="story theme-summary ">
+                                        <a class="story-link" href="https://www.nytimes.com/2016/11/10/us/trump-election-protest-berkeley-oakland.html">
+
+                                            <div class="thumb">
+                                                <img src="https://static01.nyt.com/images/2016/11/10/us/10trumpprotest/10trumpprotest-thumbStandard.jpg" role="presentation" alt="" />
+                                                <div class="media-action-overlay"></div>
+                                            </div>
+
+                                            <div class="story-body">
+                                                <h2 class="headline">
+                                                    <span class="title">Anti-Trump Demonstrators Take to the Streets in Several U.S. Cities</span>
+                                                    <time class="dateline">NOV. 9, 2016</time>
+                                                </h2>
+                                            </div>
+                                        </a>
+                                    </article>
+                                    </li>
+                                    <li><article class="story theme-summary ">
+                                        <a class="story-link" href="https://www.nytimes.com/video/us/100000004759928/student-protests-break-out-nationwide.html">
+
+                                            <div class="thumb">
+                                                <img src="https://static01.nyt.com/images/2016/11/09/multimedia/10elex-protests/10elex-protests-thumbStandard.jpg" role="presentation" alt="" />
+                                                <div class="media-action-overlay"><i class="icon sprite-icon video-icon"></i>
+                                                    <span class="visually-hidden">video</span>
+                                                </div>
+                                            </div>
+
+                                            <div class="story-body">
+                                                <h2 class="headline">
+                                                    <span class="title">Student Protests Break Out Nationwide</span>
+                                                    <time class="dateline">NOV. 9, 2016</time>
+                                                </h2>
+                                            </div>
+                                        </a>
+                                    </article>
+                                    </li>
+                                    <li><article class="story theme-summary ">
+                                        <a class="story-link" href="https://www.nytimes.com/2016/11/10/us/politics/donald-trump-election-reaction.html">
+
+                                            <div class="thumb">
+                                                <img src="https://static01.nyt.com/images/2016/11/10/us/10SHOCK1/10SHOCK1-thumbStandard.jpg" role="presentation" alt="" />
+                                                <div class="media-action-overlay"></div>
+                                            </div>
+
+                                            <div class="story-body">
+                                                <h2 class="headline">
+                                                    <span class="title">Donald Trump’s Victory Is Met With Shock Across a Wide Political Divide</span>
+                                                    <time class="dateline">NOV. 9, 2016</time>
+                                                </h2>
+                                            </div>
+                                        </a>
+                                    </article>
+                                    </li>
+                                </ul>
+                            </div>
+                        </aside>
+                    </div>
+                    <div class="supplemental-sub-item" data-attribute-position="1" data-attribute-name="PaidPost" data-attribute-type="PaidPost" data-attribute-subtype="">
+                        <aside id='middle-right-paid-post-container' class='ad middle-right-ad paid-post-ad marginalia-item hidden nocontent robots-nocontent'>
+                            <h2 class='marginalia-heading'></h2>
+                            <ul class='story-menu'>
+                                <li id='MiddleRightPaidPost1' class='story-menu-item ad'></li>
+                                <li id='MiddleRightPaidPost2' class='story-menu-item ad'></li>
+                                <li id='MiddleRightPaidPost3' class='story-menu-item ad'></li>
+                                <li id='MiddleRightPaidPost4' class='story-menu-item ad'></li>
+                            </ul>
+                        </aside>
+                    </div>
+                </div>
+
+            </article>
+            <section id="related-combined-coverage" class="related-combined-coverage nocontent robots-nocontent">
+                <header class="section-header">
+                    <h2 class="section-heading">Related Coverage</h2>
+                </header>
+                <div class="section-body">
+                    <ol class="story-menu menu">
+                        <li><article class="story theme-summary ">
+                            <a class="story-link" href="https://www.nytimes.com/2016/11/10/us/trump-election-protest-berkeley-oakland.html">
+                                <div class="story-body">
+                                    <h2 class="headline">
+                                        <span class="title">Anti-Trump Demonstrators Take to the Streets in Several U.S. Cities</span>
+                                        <time class="dateline">NOV. 9, 2016</time>
+                                    </h2>
+                                </div>
+
+                                <div class="thumb">
+                                    <img src="https://static01.nyt.com/images/2016/11/10/us/10trumpprotest/10trumpprotest-thumbStandard.jpg" role="presentation" alt="" />
+                                    <div class="media-action-overlay"></div>
+                                </div>
+                            </a>
+                        </article>
+                        </li>
+                        <li><article class="story theme-summary ">
+                            <a class="story-link" href="https://www.nytimes.com/video/us/100000004759928/student-protests-break-out-nationwide.html">
+                                <div class="story-body">
+                                    <h2 class="headline">
+                                        <span class="title">Student Protests Break Out Nationwide</span>
+                                        <time class="dateline">NOV. 9, 2016</time>
+                                    </h2>
+                                </div>
+
+                                <div class="thumb">
+                                    <img src="https://static01.nyt.com/images/2016/11/09/multimedia/10elex-protests/10elex-protests-thumbStandard.jpg" role="presentation" alt="" />
+                                    <div class="media-action-overlay"><i class="icon sprite-icon video-icon"></i>
+                                        <span class="visually-hidden">video</span>
+                                    </div>
+                                </div>
+                            </a>
+                        </article>
+                        </li>
+                        <li><article class="story theme-summary ">
+                            <a class="story-link" href="https://www.nytimes.com/2016/11/10/us/politics/donald-trump-election-reaction.html">
+                                <div class="story-body">
+                                    <h2 class="headline">
+                                        <span class="title">Donald Trump’s Victory Is Met With Shock Across a Wide Political Divide</span>
+                                        <time class="dateline">NOV. 9, 2016</time>
+                                    </h2>
+                                </div>
+
+                                <div class="thumb">
+                                    <img src="https://static01.nyt.com/images/2016/11/10/us/10SHOCK1/10SHOCK1-thumbStandard.jpg" role="presentation" alt="" />
+                                    <div class="media-action-overlay"></div>
+                                </div>
+                            </a>
+                        </article>
+                        </li>
+                    </ol>
+                </div>
+            </section>
+
+            <!-- While running BundlePayFlow test, hide this module if user is in test) -->
+            <script type="text/javascript">
+                if (window.NYTD && window.NYTD.Abra && window.NYTD.Abra('www-STORY_3bundlePayflow-v3') === '1') {
+                    (function() {
+                        require(['foundation/main'], function () {
+                            require(['jquery/nyt', 'foundation/models/user-data'], function ($, userData) {
+                                if (!userData.hasSynced) {
+                                    userData.on('change', function() {
+                                        checkSubStatus();
+                                    });
+                                } else {
+                                    checkSubStatus();
+                                }
+
+                                function checkSubStatus() {
+                                    if (!userData.isHomeDeliverySubscriber() &&
+                                        !userData.isWebSubscriber() &&
+                                        !userData.isMobileSubscriber() &&
+                                        !userData.isTabletSubscriber()) {
+                                        var relatedCoverage = document.querySelector('.related-combined-coverage');
+                                        if (relatedCoverage && relatedCoverage.parentNode) {
+                                            relatedCoverage.parentNode.removeChild(relatedCoverage);
+                                        }
+                                    }
+                                }
+                            });
+                        });
+                    })();
+                }
+            </script>
+            <section class="module bundle-payflow-module"><div class="bundle-payflow hidden">
+
+                <div class="branding">
+                    <img class="logo" data-src="https://a1.nyt.com/assets/article/20170403-111158/images/foundation/logos/nyt-logo-185x26.svg" alt="The New York Times" />
+                    <div class="header">Discover the truth with us. Select the package that works for you.</div>
+                    <div class="tagline">Choose annual billing and save up to 40% every year. You may cancel anytime.</div>
+                </div><!-- close branding -->
+
+                <div class="bundles-container">
+
+                    <!-- Basic Bundle -->
+                    <a href="https://myaccount.nytimes.com/get-started/auth?OC=20000050400&amp;campaignId=6KJKF" data-oc="20000050400" class="sub-link" data-target="basic">
+                        <div class="bundle-tab basic">
+                            <div class="tab-header">
+                                <div class="title">Basic</div>
+                                <div class="image">
+                                    <img class="the-image" data-src="https://static01.nyt.com/subscriptions/components/img/devices/all-access.png" alt="Basic" />
+                                </div>
+                                <div class="price">$2.75/week</div>
+                                <div class="annual">Billed as $143 every year</div>
+                                <a class="cta-button" href="https://myaccount.nytimes.com/get-started/auth?OC=20000050400&amp;campaignId=6KJKF" data-target="basic" data-oc="20000050400">Get basic</a>
+                            </div><!-- close tab-header -->
+
+                            <div class="feature-header bundle-feature">Basic Digital Access includes:</div>
+
+                            <div class="bundle-feature">
+                                <p class="feature-text bullet">Access to NYTimes.com and all NYTimes apps</p>
+                            </div>
+
+                            <div class="bundle-feature">
+                                <p class="feature-text bullet">Unlimited article access, anytime, anywhere</p>
+                            </div>
+
+                            <div class="bundle-feature">
+                                <p class="feature-text"><a href="https://www.nytimes.com/subscriptions/Multiproduct/lp8HYKU.html?campaignId=6KJKJ" class="learn-more"  data-target="learn-more"><span class="text">Learn more </span><span class="arrow">&#x25BA;</span></a></p>
+                            </div>
+                        </div> <!-- close bundle tab -->
+                    </a> <!-- close bundle link -->
+
+                    <!-- All Access Bundle -->
+                    <a href="https://myaccount.nytimes.com/get-started/auth?OC=20000056980&amp;campaignId=6KJKF" class="sub-link" data-target="all-access" data-oc="20000056980">
+                        <div class="bundle-tab all-access">
+                            <div class="tab-header">
+                                <div class="title">All Access</div>
+                                <div class="image">
+                                    <img class="the-image" data-src="https://static01.nyt.com/subscriptions/components/img/devices/all-access-plus-insider.png" alt="All Access" />
+                                </div>
+                                <div class="price">$3.75/week</div>
+                                <div class="annual">Billed as $195 every year</div>
+                                <a class="cta-button" href="https://myaccount.nytimes.com/get-started/auth?OC=20000056980&amp;campaignId=6KJKF" data-target="all-access" data-oc="20000056980">Get All Access</a>
+                            </div><!-- close tab-header -->
+
+                            <div class="feature-header bundle-feature">Includes everything in Basic, <span class="italic">plus:</span></div>
+
+                            <div class="bundle-feature">
+                                <p class="feature-text bullet">Times Insider Access, including behind-the-scenes stories, exclusive events, podcasts, and e-books</p>
+                            </div>
+
+                            <div class="bundle-feature">
+                                <p class="feature-text bullet">1 complimentary digital subscription to give anyone you'd like</p>
+                            </div>
+                            <div class="bundle-feature">
+                                <p class="feature-text"><a href="https://www.nytimes.com/subscriptions/Multiproduct/lp8HYKU.html?campaignId=6KJKJ" class="learn-more" data-target="learn-more"><span class="text">Learn more </span><span class="arrow">&#x25BA;</span></a></p>
+                            </div>
+                        </div> <!-- close bundle tab -->
+                    </a> <!-- close bundle link -->
+
+                    <!-- Home Delivery Bundle -->
+                    <a href="https://www.nytimes.com/subscriptions/hd/365.html?MediaCode=WB7AA&amp;CMP=6KJKF" class="sub-link" data-target="home-delivery">
+                        <div class="bundle-tab home-delivery">
+                            <div class="tab-header">
+                                <div class="title">Home Delivery<br /><span class="sub-title">+ All Access</span></div>
+                                <div class="image">
+                                    <img class="the-image" data-src="https://static01.nyt.com/subscriptions/components/img/devices/products_hd.png" alt="Home Delivery" />
+                                </div>
+                                <div class="price">$6.93/week</div>
+                                <div class="annual">Billed as $360 every year*</div>
+                                <a class="cta-button" href="https://www.nytimes.com/subscriptions/hd/365.html?MediaCode=WB7AA&amp;CMP=6KJKF" data-target="home-delivery">Get Home Delivery</a>
+                            </div><!-- close tab-header -->
+
+                            <div class="feature-header bundle-feature">Includes everything in All Access, <span class="italic">plus:</span></div>
+
+                            <div class="bundle-feature">
+                                <p class="feature-text bullet">Customized delivery options such as Sunday only, Fri.-Sun., weekday delivery, or daily delivery</p>
+                            </div>
+
+                            <div class="bundle-feature">
+                                <p class="feature-text bullet">The weekly Sunday magazine and monthly T Magazine</p>
+                            </div>
+                            <div class="bundle-feature">
+                                <p class="feature-text bullet">2 complimentary digital subscriptions to give anyone you'd like</p>
+                            </div>
+                            <div class="bundle-feature">
+                                <p class="feature-text"><a href="https://www.nytimes.com/subscriptions/Multiproduct/lp8HYKU.html?campaignId=6KJKJ" class="learn-more" data-target="learn-more"><span class="text">Learn more </span><span class="arrow">&#x25BA;</span></a></p>
+                            </div>
+                        </div> <!-- close bundle tab -->
+                    </a> <!-- close bundle link -->
+
+                </div><!-- close bundle container -->
+
+                <div class="disclaimer">
+                    <div class="text">*Home delivery price based on Sunday delivery.<br>Prices vary based on delivery location and frequency.</div>
+                </div>
+
+            </div> <!-- end bundle-payflow -->
+
+            </section>
+
+
+            <aside class="module trending-module hidden nocontent robots-nocontent" data-truncate-enabled="true"></aside><section id="whats-next" class="whats-next nocontent robots-nocontent">
+            <h2 class="visually-hidden">What's Next</h2>
+            <div class="nocontent robots-nocontent">
+                <div class="loader-container">
+                    <div class="loader loader-t-logo-32x32-ecedeb-ffffff"><span class="visually-hidden">Loading...</span></div>
+                </div>
+            </div><!-- close nocontent -->
+        </section>
+            <div id="TopAd1" class="text-ad bottom-left-ad nocontent robots-nocontent"></div>
+            <div id="Top5" class="ad top5-ad hidden nocontent robots-nocontent"></div>
+            <div class="search-overlay"></div>
+        </main><!-- close main -->
+        <section id="site-index" class="site-index">
+            <header class="section-header">
+                <p class="user-action"><a href="http://www.nytimes.com/">Go to Home Page &raquo;</a></p>
+                <h2 class="section-heading">
+                    <span class="visually-hidden">Site Index</span>
+                    <a id="site-index-branding-link" href="http://www.nytimes.com/">
+                        <span class="visually-hidden">The New York Times</span>
+                    </a>
+                </h2>
+                <script>window.magnum.writeLogo('small', 'https://a1.nyt.com/assets/article/20170403-111158/images/foundation/logos/', '', '', 'standard', 'site-index-branding-link', '');</script>
+            </header>
+
+            <nav id="site-index-navigation" class="site-index-navigation" role="navigation">
+                <h2 class="visually-hidden">Site Index Navigation</h2>
+                <div class="split-6-layout layout">
+
+
+                    <div class="column">
+                        <h3 class="menu-heading">News</h3>
+                        <ul class="menu">
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/world/index.html">World</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/national/index.html">U.S.</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/politics/index.html">Politics</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/nyregion/index.html">N.Y.</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/business/index.html">Business</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/technology/index.html">Tech</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/section/science">Science</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/health/index.html">Health</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/sports/index.html">Sports</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/education/index.html">Education</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/obituaries/index.html">Obituaries</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/todayspaper/index.html">Today's Paper</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/corrections/index.html">Corrections</a>
+                            </li>
+
+
+                        </ul>
+                    </div><!-- close column -->
+
+
+                    <div class="column">
+                        <h3 class="menu-heading">Opinion</h3>
+                        <ul class="menu">
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/opinion/index.html">Today's Opinion</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/opinion/index.html#columnists">Op-Ed Columnists</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/opinion/index.html#editorials">Editorials</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/opinion/index.html#contributing">Contributing Writers</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/opinion/index.html#op-ed">Op-Ed Contributors</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/opinion/index.html#opinionator">Opinionator</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/opinion/index.html#letters">Letters</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/opinion/index.html#sundayreview">Sunday Review</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/opinion/index.html#takingNote">Taking Note</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/roomfordebate">Room for Debate</a>
+                            </li>
+
+
+                            <li>
+                                <a href="http://topics.nytimes.com/top/opinion/thepubliceditor/index.html">Public Editor</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/video/opinion">Video: Opinion</a>
+                            </li>
+
+
+                        </ul>
+                    </div><!-- close column -->
+
+
+                    <div class="column">
+                        <h3 class="menu-heading">Arts</h3>
+                        <ul class="menu">
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/arts/index.html">Today's Arts</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/arts/design/index.html">Art & Design</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/books/index.html">Books</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/arts/dance/index.html">Dance</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/movies/index.html">Movies</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/arts/music/index.html">Music</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/events/">N.Y.C. Events Guide</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/arts/television/index.html">Television</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/theater/index.html">Theater</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/video/arts">Video: Arts</a>
+                            </li>
+
+
+                        </ul>
+                    </div><!-- close column -->
+
+
+                    <div class="column">
+                        <h3 class="menu-heading">Living</h3>
+                        <ul class="menu">
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/automobiles/index.html">Automobiles</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/crosswords/">Crossword</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/dining/index.html">Food</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/education/index.html">Education</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/fashion/index.html">Fashion & Style</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/health/index.html">Health</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/section/jobs">Jobs</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/magazine/index.html">Magazine</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/events/">N.Y.C. Events Guide</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/section/realestate">Real Estate</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/section/t-magazine">T Magazine</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/section/travel">Travel</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/fashion/weddings/index.html">Weddings & Celebrations</a>
+                            </li>
+
+
+                        </ul>
+                    </div><!-- close column -->
+
+
+                    <div class="column">
+                        <h3 class="menu-heading">Listings & More</h3>
+                        <ul class="menu">
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/ref/classifieds/">Classifieds</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/marketing/tools-and-services/">Tools & Services</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/topics/">Times Topics</a>
+                            </li>
+
+
+                            <li>
+                                <a href="http://topics.nytimes.com/top/opinion/thepubliceditor/index.html">Public Editor</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/events/">N.Y.C. Events Guide</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/interactive/blogs/directory.html">Blogs</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/pages/multimedia/index.html">Multimedia</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://lens.blogs.nytimes.com/">Photography</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/video">Video</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/store/?&t=qry542&utm_source=nytimes&utm_medium=HPB&utm_content=hp_browsetree&utm_campaign=NYT-HP&module=SectionsNav&action=click&region=TopBar&version=BrowseTree&contentCollection=NYT%20Store&contentPlacement=2&pgtype=Homepage">NYT Store</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/times-journeys/?utm_source=nytimes&utm_medium=HPLink&utm_content=hp_browsetree&utm_campaign=NYT-HP">Times Journeys</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/seeallnav">Subscribe</a>
+                            </li>
+
+
+                            <li>
+                                <a href="https://www.nytimes.com/membercenter">Manage My Account</a>
+                            </li>
+
+
+                        </ul>
+                    </div><!-- close column -->
+
+
+                    <div class="column last-column">
+
+                        <h3 class="menu-heading">Subscribe</h3>
+
+                        <ul class="menu primary-menu">
+                            <li class="menu-label">Subscribe</li>
+                            <li class="home-delivery">
+                                <i class="icon sprite-icon"></i>
+                                <a href="http://www.nytimes.com/hdleftnav">Home Delivery</a>
+                            </li>
+                            <li class="digital-subscriptions">
+                                <i class="icon sprite-icon"></i>
+                                <a href="http://www.nytimes.com/digitalleftnav">Digital Subscriptions</a>
+                            </li>
+                            <li class="times-premier">
+                                <i class="icon sprite-icon"></i>
+                                <a href="http://www.nytimes.com/tpnav">Times Insider</a>
+                            </li>
+                            <li class="nyt-crossword last-item">
+                                <i class="icon sprite-icon"></i>
+                                <a id="nyt-crossword" href="http://www.nytimes.com/crosswords/index.html">Crossword</a>
+                            </li>
+                        </ul>
+
+                        <ul class="menu secondary-menu">
+
+                            <li>
+                                <a href="http://www.nytimes.com/marketing/newsletters">Email Newsletters</a>
+                            </li>
+                            <li>
+                                <a href="https://myaccount.nytimes.com/mem/tnt.html">Alerts</a>
+                            </li>
+                            <li>
+                                <a href="http://www.nytimes.com/giftleftnav">Gift Subscriptions</a>
+                            </li>
+                            <li>
+                                <a href="http://www.nytimes.com/corporateleftnav">Corporate Subscriptions</a>
+                            </li>
+                            <li>
+                                <a href="http://www.nytimes.com/educationleftnav">Education Rate</a>
+                            </li>
+
+                        </ul>
+                        <ul class="menu secondary-menu">
+                            <li>
+                                <a href="http://www.nytimes.com/services/mobile/index.html">Mobile Applications</a>
+                            </li>
+                            <li>
+                                <a href="http://eedition.nytimes.com/cgi-bin/signup.cgi?cc=37FYY">Replica Edition</a>
+                            </li>
+
+                        </ul>
+
+                    </div><!-- close column -->
+
+                </div><!-- close split-6-layout -->
+
+            </nav><!-- close nav -->
+
+        </section><!-- close site-index -->
+
+        <footer id="page-footer" class="page-footer" role="contentinfo">
+            <nav>
+                <h2 class="visually-hidden">Site Information Navigation</h2>
+                <ul>
+                    <li>
+                        <a href="http://www.nytimes.com/content/help/rights/copyright/copyright-notice.html" itemprop="copyrightNotice">
+                            &copy; <span itemprop="copyrightYear">2017</span><span itemprop="copyrightHolder provider sourceOrganization" itemscope itemtype="http://schema.org/Organization" itemid="http://www.nytimes.com"><span itemprop="name"> The New York Times Company</span><meta itemprop="tickerSymbol" content="NYSE NYT"/></span>
+                        </a>
+                    </li>
+                    <li class="visually-hidden"><a href="http://www.nytimes.com">Home</a></li>
+                    <li class="visually-hidden"><a href="http://query.nytimes.com/search/sitesearch/#/">Search</a></li>
+                    <li class="visually-hidden">Accessibility concerns? Email us at <a href="mailto:accessibility@nytimes.com">accessibility@nytimes.com</a>. We would love to hear from you.</li>
+                    <li class="wide-viewport-item"><a href="http://www.nytimes.com/ref/membercenter/help/infoservdirectory.html">Contact Us</a></li>
+                    <li class="wide-viewport-item"><a href="http://www.nytco.com/careers">Work With Us</a></li>
+                    <li class="wide-viewport-item"><a href="http://nytmediakit.com/">Advertise</a></li>
+                    <li class="wide-viewport-item"><a href="http://www.nytimes.com/content/help/rights/privacy/policy/privacy-policy.html#pp">Your Ad Choices</a></li>
+                    <li><a href="http://www.nytimes.com/privacy">Privacy</a></li>
+                    <li><a href="http://www.nytimes.com/ref/membercenter/help/agree.html" itemprop="usageTerms">Terms of Service</a></li>
+                    <li class="wide-viewport-item last-item"><a href="http://www.nytimes.com/content/help/rights/sale/terms-of-sale.html">Terms of Sale</a></li>
+                </ul>
+            </nav>
+            <nav class="last-nav">
+                <h2 class="visually-hidden">Site Information Navigation</h2>
+                <ul>
+                    <li><a href="http://spiderbites.nytimes.com">Site Map</a></li>
+                    <li><a href="http://www.nytimes.com/membercenter/sitehelp.html">Help</a></li>
+                    <li><a href="https://myaccount.nytimes.com/membercenter/feedback.html">Site Feedback</a></li>
+                    <li class="wide-viewport-item last-item"><a href="http://www.nytimes.com/subscriptions/Multiproduct/lp5558.html?campaignId=37WXW">Subscriptions</a></li>
+                </ul>
+            </nav>
+        </footer>
+    </div><!-- close page -->
+</div><!-- close shell -->
+<script src="https://cdn.optimizely.com/public/3013110282/s/article_prod.js" type="text/javascript" async></script>
+<script>
+    require(['foundation/main'], function () {
+        require(['story/main']);
+        require(['jquery/nyt', 'foundation/views/page-manager'], function ($, pageManager) {
+            if (window.location.search.indexOf('disable_tagx') > 0) {
+                return;
+            }
+            $(document).ready(function () {
+                require(['https://a1.nyt.com/analytics/tagx-simple.min.js'], function () {
+                    pageManager.trackingFireEventQueue();
+                });
+            });
+        });
+    });
+</script>
+<!--esi
+<esi:include src="/appconfig/https/show-modal.js" />
+-->
+
+<div id="Inv1" class="ad inv1-ad hidden"></div>
+<div id="Inv2" class="ad inv2-ad hidden"></div>
+<div id="Inv3" class="ad inv3-ad hidden"></div>
+<div id="ab1" class="ad ab1-ad hidden"></div>
+<div id="ab2" class="ad ab2-ad hidden"></div>
+<div id="ab3" class="ad ab3-ad hidden"></div>
+<div id="prop1" class="ad prop1-ad hidden"></div>
+<div id="prop2" class="ad prop2-ad hidden"></div>
+<div id="Anchor" class="ad anchor-ad hidden"></div>
+<div id="ADX_CLIENTSIDE" class="ad adx-clientside-ad hidden"></div>
+</body>
+</html>


### PR DESCRIPTION
We encountered an issue with NYT articles where article content was split across sibling nodes. Only the most significant part of the article was extracted leaving out a number of paragraphs prior to the extracted content. Our approach was to concatenate these sibling nodes. 

We've included a unit test and existing unit tests pass.

Would like to get your input and if a good solution please merge.

Thank you,