### PR TITLE
Extract text, title, etc from url without fetch url (avoid its downloading)

### DIFF
--- a/src/main/java/de/jetwick/snacktory/HtmlFetcher.java
+++ b/src/main/java/de/jetwick/snacktory/HtmlFetcher.java
@@ -292,6 +292,94 @@ public class HtmlFetcher {
         }
         return result;
     }
+    
+    /**
+     * extract parsed content: title, text ..,  without fetch url (avoid download  url´s content). 
+     * @param url
+     * @param content
+     * @param timeout
+     * @param resolve
+     * @return
+     * @throws Exception
+     */
+    public JResult extract(String url, byte[] content, int timeout, boolean resolve) throws Exception {
+        String originalUrl = url;
+        url = SHelper.removeHashbang(url);
+        String gUrl = SHelper.getUrlFromUglyGoogleRedirect(url);
+        if (gUrl != null)
+            url = gUrl;
+        else {
+            gUrl = SHelper.getUrlFromUglyFacebookRedirect(url);
+            if (gUrl != null)
+                url = gUrl;
+        }
+
+        if (resolve) {
+            // check if we can avoid resolving the URL (which hits the website!)
+            JResult res = getFromCache(url, originalUrl);
+            if (res != null)
+                return res;
+
+            String resUrl = getResolvedUrl(url, timeout);
+            if (resUrl.isEmpty()) {
+                if (logger.isDebugEnabled())
+                    logger.warn("resolved url is empty. Url is: " + url);
+
+                JResult result = new JResult();
+                if (cache != null)
+                    cache.put(url, result);
+                return result.setUrl(url);
+            }
+
+            // if resolved url is longer then use it!
+            if (resUrl != null && resUrl.trim().length() > url.length()) {
+                // this is necessary e.g. for some homebaken url resolvers which return
+                // the resolved url relative to url!
+                url = SHelper.useDomainOfFirstArg4Second(url, resUrl);
+            }
+        }
+
+        // check if we have the (resolved) URL in cache
+        JResult res = getFromCache(url, originalUrl);
+        if (res != null)
+            return res;
+
+        JResult result = new JResult();
+        // or should we use? <link rel="canonical" href="http://www.N24.de/news/newsitem_6797232.html"/>
+        result.setUrl(url);
+        result.setOriginalUrl(originalUrl);
+        result.setDate(SHelper.estimateDate(url));
+
+        // Immediately put the url into the cache as extracting content takes time.
+        if (cache != null) {
+            cache.put(originalUrl, result);
+            cache.put(url, result);
+        }
+
+        String lowerUrl = url.toLowerCase();
+        if (SHelper.isDoc(lowerUrl) || SHelper.isApp(lowerUrl) || SHelper.isPackage(lowerUrl)) {
+            // skip
+        } else if (SHelper.isVideo(lowerUrl) || SHelper.isAudio(lowerUrl)) {
+            result.setVideoUrl(url);
+        } else if (SHelper.isImage(lowerUrl)) {
+            result.setImageUrl(url);
+        } else {
+            extractor.extractContent(result, new String(content, charset));
+            if (result.getFaviconUrl().isEmpty())
+                result.setFaviconUrl(SHelper.getDefaultFavicon(url));
+
+            // some links are relative to root and do not include the domain of the url :(
+            result.setFaviconUrl(fixUrl(url, result.getFaviconUrl()));
+            result.setImageUrl(fixUrl(url, result.getImageUrl()));
+            result.setVideoUrl(fixUrl(url, result.getVideoUrl()));
+            result.setRssUrl(fixUrl(url, result.getRssUrl()));
+        }
+        result.setText(lessText(result.getText()));
+        synchronized (result) {
+            result.notifyAll();
+        }
+        return result;
+    }
 
     public String lessText(String text) {
         if (text == null)


### PR DESCRIPTION
I publish a new method in HtmlFetcher called extract which has a new parameter (content) to pass byte[] content from url.

I would like to avoid downloading the url´s content. 
Sometimes, I have previously url´s content and I want to avoid a new downloading from the url (specially 'very huge url´s content).